### PR TITLE
GpuStorageNode Phase 2: type support, incoming sets, bulk ops

### DIFF
--- a/opencog/gpu/CMakeLists.txt
+++ b/opencog/gpu/CMakeLists.txt
@@ -10,6 +10,7 @@
 SET(OPENCL_KERNEL_FILES
 	gpu-hashtable.cl
 	gpu-atomspace.cl
+	gpu-incoming.cl
 	gpu-mi.cl
 	gpu-cosine.cl
 	gpu-counting.cl

--- a/opencog/gpu/gpu-incoming.cl
+++ b/opencog/gpu/gpu-incoming.cl
@@ -1,0 +1,48 @@
+/*
+ * gpu-incoming.cl -- Parallel incoming-set scan for pair pool
+ *
+ * Scans the pair pool to find all pairs that reference a given
+ * word index (as either word_a or word_b). This implements the
+ * GPU-side of fetchIncomingByType for GpuStorageNode.
+ *
+ * One thread per pair slot. Matching pairs write their index
+ * into the output array via atomic increment on match_count.
+ *
+ * This file is concatenated after gpu-hashtable.cl and
+ * gpu-atomspace.cl at load time.
+ */
+
+/*
+ * Find all pairs where word_a == target OR word_b == target.
+ *
+ * Args:
+ *   pair_word_a    - pair pool: word_a column
+ *   pair_word_b    - pair pool: word_b column
+ *   target_idx     - the word index to search for
+ *   pool_count     - number of active pairs in pool
+ *   match_indices  - output: pair indices that match
+ *   match_count    - output: atomic counter of matches
+ *   max_matches    - maximum output capacity
+ */
+__kernel void incoming_scan(
+    __global const uint* pair_word_a,
+    __global const uint* pair_word_b,
+    uint target_idx,
+    uint pool_count,
+    __global uint* match_indices,
+    __global volatile uint* match_count,
+    uint max_matches)
+{
+    uint tid = get_global_id(0);
+    if (tid >= pool_count) return;
+
+    uint wa = pair_word_a[tid];
+    uint wb = pair_word_b[tid];
+
+    if (wa == target_idx || wb == target_idx)
+    {
+        uint pos = atomic_add(match_count, 1U);
+        if (pos < max_matches)
+            match_indices[pos] = tid;
+    }
+}

--- a/opencog/persist/gpu/CudaBackend.cu
+++ b/opencog/persist/gpu/CudaBackend.cu
@@ -14,6 +14,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <vector>
 
 #include <opencog/util/exceptions.h>
 #include <opencog/util/Logger.h>
@@ -210,6 +211,31 @@ __global__ void cuda_pair_find_or_create(
 	out_indices[idx] = CUDA_HT_EMPTY_VALUE;
 }
 
+// ----------------------------------------------------------
+// Incoming-set scan: find all pairs referencing a given word
+__global__ void cuda_incoming_scan(
+	const uint32_t* __restrict__ pair_word_a,
+	const uint32_t* __restrict__ pair_word_b,
+	uint32_t target_idx,
+	uint32_t pool_count,
+	uint32_t* __restrict__ match_indices,
+	uint32_t* __restrict__ match_count,
+	uint32_t max_matches)
+{
+	uint32_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+	if (tid >= pool_count) return;
+
+	uint32_t wa = pair_word_a[tid];
+	uint32_t wb = pair_word_b[tid];
+
+	if (wa == target_idx || wb == target_idx)
+	{
+		uint32_t pos = atomicAdd(match_count, 1U);
+		if (pos < max_matches)
+			match_indices[pos] = tid;
+	}
+}
+
 // ==============================================================
 // Host-side Implementation
 // ==============================================================
@@ -218,7 +244,7 @@ CudaBackend::CudaBackend()
 	: _device_id(-1),
 	  _d_word_name_hash(nullptr), _d_word_count(nullptr),
 	  _d_word_mi_marginal(nullptr), _d_word_class_id(nullptr),
-	  _d_word_next_free(nullptr),
+	  _d_word_type(nullptr), _d_word_next_free(nullptr),
 	  _d_pair_word_a(nullptr), _d_pair_word_b(nullptr),
 	  _d_pair_count(nullptr), _d_pair_mi(nullptr),
 	  _d_pair_flags(nullptr), _d_pair_next_free(nullptr),
@@ -310,6 +336,7 @@ void CudaBackend::shutdown()
 	if (_d_word_count)     cudaFree(_d_word_count);
 	if (_d_word_mi_marginal) cudaFree(_d_word_mi_marginal);
 	if (_d_word_class_id)  cudaFree(_d_word_class_id);
+	if (_d_word_type)      cudaFree(_d_word_type);
 	if (_d_word_next_free) cudaFree(_d_word_next_free);
 
 	if (_d_pair_word_a)    cudaFree(_d_pair_word_a);
@@ -342,6 +369,7 @@ void CudaBackend::shutdown()
 	_d_word_count = nullptr;
 	_d_word_mi_marginal = nullptr;
 	_d_word_class_id = nullptr;
+	_d_word_type = nullptr;
 	_d_word_next_free = nullptr;
 	_d_pair_word_a = nullptr;
 	_d_pair_word_b = nullptr;
@@ -386,6 +414,8 @@ void CudaBackend::alloc_pools()
 		sizeof(double) * GPU_WORD_CAPACITY), "alloc word_mi_marginal");
 	check_error(cudaMalloc(&_d_word_class_id,
 		sizeof(uint32_t) * GPU_WORD_CAPACITY), "alloc word_class_id");
+	check_error(cudaMalloc(&_d_word_type,
+		sizeof(uint16_t) * GPU_WORD_CAPACITY), "alloc word_type");
 	check_error(cudaMalloc(&_d_word_next_free,
 		sizeof(uint32_t)), "alloc word_next_free");
 
@@ -445,6 +475,9 @@ void CudaBackend::init_pools()
 	cudaMemcpy(_d_word_next_free, &zero, sizeof(uint32_t), cudaMemcpyHostToDevice);
 	cudaMemcpy(_d_pair_next_free, &zero, sizeof(uint32_t), cudaMemcpyHostToDevice);
 	cudaMemcpy(_d_sec_next_free, &zero, sizeof(uint32_t), cudaMemcpyHostToDevice);
+
+	// Zero out word type array
+	cudaMemset(_d_word_type, 0, sizeof(uint16_t) * GPU_WORD_CAPACITY);
 
 	// Initialize hash table keys to EMPTY (0xFF bytes)
 	cudaMemset(_d_word_ht_keys,   0xFF, sizeof(uint64_t) * GPU_WORD_HT_CAPACITY);
@@ -512,6 +545,20 @@ void CudaBackend::word_read_values(uint32_t idx,
 		sizeof(double), cudaMemcpyDeviceToHost);
 }
 
+void CudaBackend::word_write_type(uint32_t idx, uint16_t type)
+{
+	cudaMemcpy(_d_word_type + idx, &type,
+		sizeof(uint16_t), cudaMemcpyHostToDevice);
+}
+
+uint16_t CudaBackend::word_read_type(uint32_t idx)
+{
+	uint16_t type = 0;
+	cudaMemcpy(&type, _d_word_type + idx,
+		sizeof(uint16_t), cudaMemcpyDeviceToHost);
+	return type;
+}
+
 void CudaBackend::word_delete(uint64_t name_hash)
 {
 	*_staging_key = name_hash;
@@ -532,7 +579,8 @@ uint32_t CudaBackend::word_pool_count()
 }
 
 void CudaBackend::word_read_bulk(uint32_t n, uint64_t* hashes,
-                                 double* counts, double* marginals)
+                                 double* counts, double* marginals,
+                                 uint16_t* types)
 {
 	cudaMemcpy(hashes, _d_word_name_hash,
 		sizeof(uint64_t) * n, cudaMemcpyDeviceToHost);
@@ -540,6 +588,8 @@ void CudaBackend::word_read_bulk(uint32_t n, uint64_t* hashes,
 		sizeof(double) * n, cudaMemcpyDeviceToHost);
 	cudaMemcpy(marginals, _d_word_mi_marginal,
 		sizeof(double) * n, cudaMemcpyDeviceToHost);
+	cudaMemcpy(types, _d_word_type,
+		sizeof(uint16_t) * n, cudaMemcpyDeviceToHost);
 }
 
 // ==============================================================
@@ -601,12 +651,100 @@ void CudaBackend::pair_read_values(uint32_t idx,
 		sizeof(double), cudaMemcpyDeviceToHost);
 }
 
+void CudaBackend::pair_write_type(uint32_t idx, uint16_t type)
+{
+	uint32_t val = (uint32_t)type;
+	cudaMemcpy(_d_pair_flags + idx, &val,
+		sizeof(uint32_t), cudaMemcpyHostToDevice);
+}
+
+uint16_t CudaBackend::pair_read_type(uint32_t idx)
+{
+	uint32_t val = 0;
+	cudaMemcpy(&val, _d_pair_flags + idx,
+		sizeof(uint32_t), cudaMemcpyDeviceToHost);
+	return (uint16_t)val;
+}
+
 uint32_t CudaBackend::pair_pool_count()
 {
 	uint32_t cnt = 0;
 	cudaMemcpy(&cnt, _d_pair_next_free,
 		sizeof(uint32_t), cudaMemcpyDeviceToHost);
 	return cnt;
+}
+
+// ==============================================================
+// Incoming-set scan (Phase 2)
+
+uint32_t CudaBackend::incoming_scan(uint32_t target_word_idx,
+                                     uint32_t* out_pair_indices,
+                                     uint32_t max_results)
+{
+	uint32_t pool_count = pair_pool_count();
+	if (pool_count == 0) return 0;
+
+	// Allocate device output buffers
+	uint32_t* d_match_indices = nullptr;
+	uint32_t* d_match_count = nullptr;
+
+	check_error(cudaMalloc(&d_match_indices,
+		sizeof(uint32_t) * max_results), "alloc match_indices");
+	check_error(cudaMallocManaged(&d_match_count,
+		sizeof(uint32_t)), "alloc match_count");
+
+	*d_match_count = 0;
+
+	int threads = 256;
+	int blocks = (pool_count + threads - 1) / threads;
+
+	cuda_incoming_scan<<<blocks, threads>>>(
+		_d_pair_word_a, _d_pair_word_b,
+		target_word_idx, pool_count,
+		d_match_indices, d_match_count, max_results);
+	cudaDeviceSynchronize();
+
+	uint32_t n = *d_match_count;
+	if (n > max_results) n = max_results;
+
+	if (n > 0)
+	{
+		cudaMemcpy(out_pair_indices, d_match_indices,
+			sizeof(uint32_t) * n, cudaMemcpyDeviceToHost);
+	}
+
+	cudaFree(d_match_indices);
+	cudaFree(d_match_count);
+
+	return n;
+}
+
+uint32_t CudaBackend::pair_read_bulk(uint32_t n,
+                                     uint32_t* word_a, uint32_t* word_b,
+                                     double* counts, double* mis,
+                                     uint16_t* types)
+{
+	uint32_t pool_count = pair_pool_count();
+	if (pool_count == 0) return 0;
+	if (n > pool_count) n = pool_count;
+
+	cudaMemcpy(word_a, _d_pair_word_a,
+		sizeof(uint32_t) * n, cudaMemcpyDeviceToHost);
+	cudaMemcpy(word_b, _d_pair_word_b,
+		sizeof(uint32_t) * n, cudaMemcpyDeviceToHost);
+	cudaMemcpy(counts, _d_pair_count,
+		sizeof(double) * n, cudaMemcpyDeviceToHost);
+	cudaMemcpy(mis, _d_pair_mi,
+		sizeof(double) * n, cudaMemcpyDeviceToHost);
+
+	// Read pair flags and convert uint32_t -> uint16_t types
+	std::vector<uint32_t> flags(n);
+	cudaMemcpy(flags.data(), _d_pair_flags,
+		sizeof(uint32_t) * n, cudaMemcpyDeviceToHost);
+	for (uint32_t i = 0; i < n; i++)
+		types[i] = (uint16_t)flags[i];
+
+	return n;
 }
 
 // ==============================================================

--- a/opencog/persist/gpu/CudaBackend.h
+++ b/opencog/persist/gpu/CudaBackend.h
@@ -34,6 +34,7 @@ private:
 	double*   _d_word_count;
 	double*   _d_word_mi_marginal;
 	uint32_t* _d_word_class_id;
+	uint16_t* _d_word_type;
 	uint32_t* _d_word_next_free;
 
 	// Device memory -- PairPool SoA
@@ -85,10 +86,13 @@ public:
 	void word_write_marginal(uint32_t idx, double marginal) override;
 	void word_read_values(uint32_t idx,
 	                      double& count, double& marginal) override;
+	void word_write_type(uint32_t idx, uint16_t type) override;
+	uint16_t word_read_type(uint32_t idx) override;
 	void word_delete(uint64_t name_hash) override;
 	uint32_t word_pool_count() override;
 	void word_read_bulk(uint32_t n, uint64_t* hashes,
-	                    double* counts, double* marginals) override;
+	                    double* counts, double* marginals,
+	                    uint16_t* types) override;
 
 	uint32_t pair_find_or_create(uint32_t word_a,
 	                             uint32_t word_b) override;
@@ -97,9 +101,19 @@ public:
 	void pair_write_mi(uint32_t idx, double mi) override;
 	void pair_read_values(uint32_t idx,
 	                      double& count, double& mi) override;
+	void pair_write_type(uint32_t idx, uint16_t type) override;
+	uint16_t pair_read_type(uint32_t idx) override;
 	uint32_t pair_pool_count() override;
 
 	uint32_t section_pool_count() override;
+
+	uint32_t incoming_scan(uint32_t target_word_idx,
+	                       uint32_t* out_pair_indices,
+	                       uint32_t max_results) override;
+	uint32_t pair_read_bulk(uint32_t n,
+	                        uint32_t* word_a, uint32_t* word_b,
+	                        double* counts, double* mis,
+	                        uint16_t* types) override;
 
 	void barrier() override;
 };

--- a/opencog/persist/gpu/GpuBackend.h
+++ b/opencog/persist/gpu/GpuBackend.h
@@ -46,10 +46,13 @@ public:
 	virtual void word_write_marginal(uint32_t idx, double marginal) = 0;
 	virtual void word_read_values(uint32_t idx,
 	                              double& count, double& marginal) = 0;
+	virtual void word_write_type(uint32_t idx, uint16_t type) = 0;
+	virtual uint16_t word_read_type(uint32_t idx) = 0;
 	virtual void word_delete(uint64_t name_hash) = 0;
 	virtual uint32_t word_pool_count() = 0;
 	virtual void word_read_bulk(uint32_t n, uint64_t* hashes,
-	                            double* counts, double* marginals) = 0;
+	                            double* counts, double* marginals,
+	                            uint16_t* types) = 0;
 
 	// -- Pair pool operations --
 	virtual uint32_t pair_find_or_create(uint32_t word_a,
@@ -59,10 +62,29 @@ public:
 	virtual void pair_write_mi(uint32_t idx, double mi) = 0;
 	virtual void pair_read_values(uint32_t idx,
 	                              double& count, double& mi) = 0;
+	virtual void pair_write_type(uint32_t idx, uint16_t type) = 0;
+	virtual uint16_t pair_read_type(uint32_t idx) = 0;
 	virtual uint32_t pair_pool_count() = 0;
 
 	// -- Section pool operations --
 	virtual uint32_t section_pool_count() = 0;
+
+	// -- Incoming-set operations (Phase 2) --
+
+	// Parallel scan: find all pairs where word_a == target OR
+	// word_b == target. Returns the number of matches found
+	// (up to max_results). Matching pair pool indices are written
+	// to out_pair_indices.
+	virtual uint32_t incoming_scan(uint32_t target_word_idx,
+	                               uint32_t* out_pair_indices,
+	                               uint32_t max_results) = 0;
+
+	// Bulk read pair pool: read word_a, word_b, count, mi, type for
+	// the first `n` pair slots. Returns actual number read.
+	virtual uint32_t pair_read_bulk(uint32_t n,
+	                                uint32_t* word_a, uint32_t* word_b,
+	                                double* counts, double* mis,
+	                                uint16_t* types) = 0;
 
 	// -- Synchronization --
 	virtual void barrier() = 0;

--- a/opencog/persist/gpu/GpuStorageNode.cc
+++ b/opencog/persist/gpu/GpuStorageNode.cc
@@ -5,6 +5,9 @@
  * Delegates all GPU operations to a GpuBackend (CUDA or OpenCL).
  *
  * Phase 1: Store/Fetch round-trip for atoms and values.
+ * Phase 2: fetchIncomingByType, fetchIncomingSet, loadType, runQuery.
+ * Phase 2.5: Type-aware storage — atom Type stored in GPU pools,
+ *            mixed into hash key to prevent same-name collisions.
  *
  * Copyright (C) 2025 OpenCog Foundation
  *
@@ -22,6 +25,7 @@
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/value/FloatValue.h>
 #include <opencog/atoms/atom_types/atom_types.h>
+#include <opencog/atoms/atom_types/NameServer.h>
 #include <opencog/persist/gpu-types/atom_types.h>
 
 #include "GpuStorageNode.h"
@@ -60,11 +64,11 @@ GpuStorageNode::~GpuStorageNode()
 // URI parsing: "gpu://[backend:]platform:device"
 //
 // Extended URI format:
-//   "gpu://:"                  → auto backend, any device
-//   "gpu://NVIDIA:RTX"         → auto backend, NVIDIA RTX
-//   "gpu://cuda::"             → force CUDA, any device
-//   "gpu://opencl:Intel:"      → force OpenCL, Intel device
-//   "gpu://cuda:NVIDIA:RTX"    → CUDA, NVIDIA RTX
+//   "gpu://:"                  -> auto backend, any device
+//   "gpu://NVIDIA:RTX"         -> auto backend, NVIDIA RTX
+//   "gpu://cuda::"             -> force CUDA, any device
+//   "gpu://opencl:Intel:"      -> force OpenCL, Intel device
+//   "gpu://cuda:NVIDIA:RTX"    -> CUDA, NVIDIA RTX
 
 void GpuStorageNode::parse_uri(void)
 {
@@ -230,33 +234,35 @@ void GpuStorageNode::erase(void)
 }
 
 // ==============================================================
-// Name hashing
+// Name hashing — Type is mixed into the hash to prevent
+// same-name-different-type collisions.
 
-uint64_t GpuStorageNode::name_hash(const std::string& name)
+uint64_t GpuStorageNode::name_hash(Type t, const std::string& name)
 {
 	std::lock_guard<std::mutex> lk(_name_mtx);
 
-	auto it = _name_to_hash.find(name);
+	TypedName tn{t, name};
+	auto it = _name_to_hash.find(tn);
 	if (it != _name_to_hash.end())
 		return it->second;
 
-	// splitmix64 on std::hash
+	// Mix type into string hash via golden ratio constant
 	std::hash<std::string> hasher;
-	uint64_t h = hasher(name);
+	uint64_t h = hasher(name) ^ (uint64_t(t) * 0x9E3779B97F4A7C15ULL);
 
 	if (h == GPU_HT_EMPTY_KEY) h = 0;
 
-	_name_to_hash[name] = h;
-	_hash_to_name[h] = name;
+	_name_to_hash[tn] = h;
+	_hash_to_name[h] = tn;
 	return h;
 }
 
 // ==============================================================
 // GPU pool operations (delegated to backend)
 
-uint32_t GpuStorageNode::store_word(const std::string& name)
+uint32_t GpuStorageNode::store_word(Type t, const std::string& name)
 {
-	uint64_t nhash = name_hash(name);
+	uint64_t nhash = name_hash(t, name);
 	uint32_t idx = _backend->word_find_or_create(nhash);
 
 	if (idx == GPU_NOT_FOUND)
@@ -264,16 +270,18 @@ uint32_t GpuStorageNode::store_word(const std::string& name)
 			"GpuStorageNode: word pool full, cannot store '%s'\n",
 			name.c_str());
 
+	_backend->word_write_type(idx, (uint16_t)t);
 	return idx;
 }
 
-uint32_t GpuStorageNode::lookup_word(const std::string& name)
+uint32_t GpuStorageNode::lookup_word(Type t, const std::string& name)
 {
-	uint64_t nhash = name_hash(name);
+	uint64_t nhash = name_hash(t, name);
 	return _backend->word_lookup(nhash);
 }
 
-uint32_t GpuStorageNode::store_pair(uint32_t word_a, uint32_t word_b)
+uint32_t GpuStorageNode::store_pair(uint32_t word_a, uint32_t word_b,
+                                     Type link_type)
 {
 	uint32_t idx = _backend->pair_find_or_create(word_a, word_b);
 
@@ -281,6 +289,7 @@ uint32_t GpuStorageNode::store_pair(uint32_t word_a, uint32_t word_b)
 		throw RuntimeException(TRACE_INFO,
 			"GpuStorageNode: pair pool full\n");
 
+	_backend->pair_write_type(idx, (uint16_t)link_type);
 	return idx;
 }
 
@@ -358,7 +367,7 @@ void GpuStorageNode::storeAtom(const Handle& h, bool synchronous)
 	NodePtr np = NodeCast(h);
 	if (np)
 	{
-		uint32_t idx = store_word(np->get_name());
+		uint32_t idx = store_word(h->get_type(), np->get_name());
 		store_node_values(h, idx);
 
 		std::lock_guard<std::mutex> lk(_atom_mtx);
@@ -384,9 +393,9 @@ void GpuStorageNode::storeAtom(const Handle& h, bool synchronous)
 			NodePtr nb = NodeCast(hb);
 			if (na and nb)
 			{
-				uint32_t ia = store_word(na->get_name());
-				uint32_t ib = store_word(nb->get_name());
-				uint32_t pidx = store_pair(ia, ib);
+				uint32_t ia = store_word(ha->get_type(), na->get_name());
+				uint32_t ib = store_word(hb->get_type(), nb->get_name());
+				uint32_t pidx = store_pair(ia, ib, h->get_type());
 				store_link_values(h, pidx);
 
 				std::lock_guard<std::mutex> lk(_atom_mtx);
@@ -412,7 +421,7 @@ void GpuStorageNode::getAtom(const Handle& h)
 	NodePtr np = NodeCast(h);
 	if (np)
 	{
-		uint32_t idx = lookup_word(np->get_name());
+		uint32_t idx = lookup_word(h->get_type(), np->get_name());
 		if (idx == GPU_NOT_FOUND) return;
 
 		load_node_values(h, idx);
@@ -430,8 +439,8 @@ void GpuStorageNode::getAtom(const Handle& h)
 		NodePtr nb = NodeCast(hb);
 		if (na and nb)
 		{
-			uint32_t ia = lookup_word(na->get_name());
-			uint32_t ib = lookup_word(nb->get_name());
+			uint32_t ia = lookup_word(ha->get_type(), na->get_name());
+			uint32_t ib = lookup_word(hb->get_type(), nb->get_name());
 			if (ia == GPU_NOT_FOUND or ib == GPU_NOT_FOUND) return;
 
 			uint32_t pidx = lookup_pair(ia, ib);
@@ -457,7 +466,7 @@ void GpuStorageNode::storeValue(const Handle& atom, const Handle& key)
 	NodePtr np = NodeCast(atom);
 	if (np)
 	{
-		uint32_t idx = store_word(np->get_name());
+		uint32_t idx = store_word(atom->get_type(), np->get_name());
 		store_node_values(atom, idx);
 		return;
 	}
@@ -465,13 +474,15 @@ void GpuStorageNode::storeValue(const Handle& atom, const Handle& key)
 	LinkPtr lp = LinkCast(atom);
 	if (lp and lp->get_arity() == 2)
 	{
-		NodePtr na = NodeCast(lp->getOutgoingAtom(0));
-		NodePtr nb = NodeCast(lp->getOutgoingAtom(1));
+		const Handle& ha = lp->getOutgoingAtom(0);
+		const Handle& hb = lp->getOutgoingAtom(1);
+		NodePtr na = NodeCast(ha);
+		NodePtr nb = NodeCast(hb);
 		if (na and nb)
 		{
-			uint32_t ia = store_word(na->get_name());
-			uint32_t ib = store_word(nb->get_name());
-			uint32_t pidx = store_pair(ia, ib);
+			uint32_t ia = store_word(ha->get_type(), na->get_name());
+			uint32_t ib = store_word(hb->get_type(), nb->get_name());
+			uint32_t pidx = store_pair(ia, ib, atom->get_type());
 			store_link_values(atom, pidx);
 		}
 	}
@@ -488,7 +499,7 @@ void GpuStorageNode::loadValue(const Handle& atom, const Handle& key)
 	NodePtr np = NodeCast(atom);
 	if (np)
 	{
-		uint32_t idx = lookup_word(np->get_name());
+		uint32_t idx = lookup_word(atom->get_type(), np->get_name());
 		if (idx != GPU_NOT_FOUND)
 			load_node_values(atom, idx);
 		return;
@@ -497,12 +508,14 @@ void GpuStorageNode::loadValue(const Handle& atom, const Handle& key)
 	LinkPtr lp = LinkCast(atom);
 	if (lp and lp->get_arity() == 2)
 	{
-		NodePtr na = NodeCast(lp->getOutgoingAtom(0));
-		NodePtr nb = NodeCast(lp->getOutgoingAtom(1));
+		const Handle& ha = lp->getOutgoingAtom(0);
+		const Handle& hb = lp->getOutgoingAtom(1);
+		NodePtr na = NodeCast(ha);
+		NodePtr nb = NodeCast(hb);
 		if (na and nb)
 		{
-			uint32_t ia = lookup_word(na->get_name());
-			uint32_t ib = lookup_word(nb->get_name());
+			uint32_t ia = lookup_word(ha->get_type(), na->get_name());
+			uint32_t ib = lookup_word(hb->get_type(), nb->get_name());
 			if (ia != GPU_NOT_FOUND and ib != GPU_NOT_FOUND)
 			{
 				uint32_t pidx = lookup_pair(ia, ib);
@@ -525,7 +538,7 @@ void GpuStorageNode::removeAtom(AtomSpace*, const Handle& h, bool recursive)
 	NodePtr np = NodeCast(h);
 	if (np)
 	{
-		uint64_t nhash = name_hash(np->get_name());
+		uint64_t nhash = name_hash(h->get_type(), np->get_name());
 		_backend->word_delete(nhash);
 
 		std::lock_guard<std::mutex> lk(_atom_mtx);
@@ -536,16 +549,205 @@ void GpuStorageNode::removeAtom(AtomSpace*, const Handle& h, bool recursive)
 // ==============================================================
 // StorageNode API: bulk operations
 
-void GpuStorageNode::fetchIncomingSet(AtomSpace*, const Handle&)
+void GpuStorageNode::fetchIncomingSet(AtomSpace* as, const Handle& h)
 {
+	if (not _connected) return;
+
+	// fetchIncomingSet fetches all link types (type=0 means no filter).
+	fetchIncomingByType(as, h, (Type)0);
 }
 
-void GpuStorageNode::fetchIncomingByType(AtomSpace*, const Handle&, Type)
+void GpuStorageNode::fetchIncomingByType(AtomSpace* as,
+                                          const Handle& h, Type t)
 {
+	if (not _connected) return;
+
+	// We only store binary links in the pair pool.
+	NodePtr np = NodeCast(h);
+	if (nullptr == np) return;
+
+	uint32_t widx = lookup_word(h->get_type(), np->get_name());
+	if (widx == GPU_NOT_FOUND) return;
+
+	// GPU parallel scan: find all pairs containing this word
+	const uint32_t MAX_INCOMING = 16384;
+	std::vector<uint32_t> matches(MAX_INCOMING);
+	uint32_t n = _backend->incoming_scan(widx,
+		matches.data(), MAX_INCOMING);
+	if (0 == n) return;
+
+	// Bulk read the pair pool to get word indices, values, and types
+	uint32_t pool_count = _backend->pair_pool_count();
+	if (0 == pool_count) return;
+
+	std::vector<uint32_t> all_wa(pool_count), all_wb(pool_count);
+	std::vector<double> all_counts(pool_count), all_mis(pool_count);
+	std::vector<uint16_t> pair_types(pool_count);
+	_backend->pair_read_bulk(pool_count,
+		all_wa.data(), all_wb.data(),
+		all_counts.data(), all_mis.data(),
+		pair_types.data());
+
+	// Read word pool to reconstruct names and types
+	uint32_t word_count = _backend->word_pool_count();
+	std::vector<uint64_t> word_hashes(word_count);
+	std::vector<double> wcounts(word_count), wmarg(word_count);
+	std::vector<uint16_t> word_types(word_count);
+	_backend->word_read_bulk(word_count,
+		word_hashes.data(), wcounts.data(), wmarg.data(),
+		word_types.data());
+
+	// Build word-index-to-(type,name) map
+	struct TypeAndName { Type type; std::string name; };
+	std::unordered_map<uint32_t, TypeAndName> idx_to_info;
+	{
+		std::lock_guard<std::mutex> lk(_name_mtx);
+		for (uint32_t wi = 0; wi < word_count; wi++)
+		{
+			auto it = _hash_to_name.find(word_hashes[wi]);
+			if (it != _hash_to_name.end())
+				idx_to_info[wi] = {it->second.type, it->second.name};
+		}
+	}
+
+	// Reconstruct Link atoms in the target AtomSpace
+	for (uint32_t i = 0; i < n; i++)
+	{
+		uint32_t pidx = matches[i];
+		Type link_type = (Type)pair_types[pidx];
+
+		// Filter by type if requested (t==0 means all types)
+		if (t != 0 and link_type != t) continue;
+
+		uint32_t wa = all_wa[pidx];
+		uint32_t wb = all_wb[pidx];
+
+		auto ita = idx_to_info.find(wa);
+		auto itb = idx_to_info.find(wb);
+		if (ita == idx_to_info.end() or itb == idx_to_info.end())
+			continue;
+
+		Handle ha = as->add_node(ita->second.type,
+			std::string(ita->second.name));
+		Handle hb = as->add_node(itb->second.type,
+			std::string(itb->second.name));
+		Handle lnk = as->add_link(link_type, ha, hb);
+
+		double c = all_counts[pidx];
+		double m = all_mis[pidx];
+		if (c != 0.0 or m != 0.0)
+		{
+			std::vector<double> vals = {c, m};
+			lnk->setValue(truth_key(), createFloatValue(vals));
+		}
+	}
+
+	_num_fetches++;
 }
 
-void GpuStorageNode::loadType(AtomSpace*, Type)
+void GpuStorageNode::loadType(AtomSpace* as, Type t)
 {
+	if (not _connected) return;
+
+	// Check if caller is asking for a node type
+	if (nameserver().isA(t, NODE) or t == NODE)
+	{
+		// Load words from word pool, filtering by stored type
+		uint32_t nwords = _backend->word_pool_count();
+		if (0 == nwords) return;
+
+		std::vector<uint64_t> hashes(nwords);
+		std::vector<double> counts(nwords);
+		std::vector<double> marginals(nwords);
+		std::vector<uint16_t> types(nwords);
+		_backend->word_read_bulk(nwords, hashes.data(),
+			counts.data(), marginals.data(), types.data());
+
+		std::lock_guard<std::mutex> lk(_name_mtx);
+		for (uint32_t i = 0; i < nwords; i++)
+		{
+			Type stored_type = (Type)types[i];
+			// Filter: t==NODE loads all node types;
+			// otherwise only load matching type (including subtypes)
+			if (t != NODE and not nameserver().isA(stored_type, t))
+				continue;
+
+			auto it = _hash_to_name.find(hashes[i]);
+			if (it == _hash_to_name.end()) continue;
+
+			Handle h = as->add_node(stored_type,
+				std::string(it->second.name));
+			if (counts[i] != 0.0 or marginals[i] != 0.0)
+			{
+				std::vector<double> vals = {counts[i], marginals[i]};
+				h->setValue(truth_key(), createFloatValue(vals));
+			}
+		}
+		return;
+	}
+
+	// Check if caller is asking for a link type
+	if (nameserver().isA(t, LINK) or t == LINK)
+	{
+		// Load pairs from pair pool, filtering by stored link type
+		uint32_t npairs = _backend->pair_pool_count();
+		if (0 == npairs) return;
+
+		std::vector<uint32_t> wa(npairs), wb(npairs);
+		std::vector<double> counts(npairs), mis(npairs);
+		std::vector<uint16_t> pair_types(npairs);
+		_backend->pair_read_bulk(npairs,
+			wa.data(), wb.data(), counts.data(), mis.data(),
+			pair_types.data());
+
+		// Also read word pool for name+type reconstruction
+		uint32_t nwords = _backend->word_pool_count();
+		std::vector<uint64_t> word_hashes(nwords);
+		std::vector<double> wcounts(nwords), wmarg(nwords);
+		std::vector<uint16_t> word_types(nwords);
+		_backend->word_read_bulk(nwords,
+			word_hashes.data(), wcounts.data(), wmarg.data(),
+			word_types.data());
+
+		// Build index-to-(type,name) map
+		struct TypeAndName { Type type; std::string name; };
+		std::unordered_map<uint32_t, TypeAndName> idx_to_info;
+		{
+			std::lock_guard<std::mutex> lk(_name_mtx);
+			for (uint32_t i = 0; i < nwords; i++)
+			{
+				auto it = _hash_to_name.find(word_hashes[i]);
+				if (it != _hash_to_name.end())
+					idx_to_info[i] = {it->second.type, it->second.name};
+			}
+		}
+
+		for (uint32_t i = 0; i < npairs; i++)
+		{
+			Type stored_link_type = (Type)pair_types[i];
+			// Filter: t==LINK loads all link types;
+			// otherwise only load matching type (including subtypes)
+			if (t != LINK and not nameserver().isA(stored_link_type, t))
+				continue;
+
+			auto ita = idx_to_info.find(wa[i]);
+			auto itb = idx_to_info.find(wb[i]);
+			if (ita == idx_to_info.end() or itb == idx_to_info.end())
+				continue;
+
+			Handle ha = as->add_node(ita->second.type,
+				std::string(ita->second.name));
+			Handle hb = as->add_node(itb->second.type,
+				std::string(itb->second.name));
+			Handle lnk = as->add_link(stored_link_type, ha, hb);
+
+			if (counts[i] != 0.0 or mis[i] != 0.0)
+			{
+				std::vector<double> vals = {counts[i], mis[i]};
+				lnk->setValue(truth_key(), createFloatValue(vals));
+			}
+		}
+	}
 }
 
 void GpuStorageNode::loadAtomSpace(AtomSpace* as)
@@ -554,29 +756,10 @@ void GpuStorageNode::loadAtomSpace(AtomSpace* as)
 		throw RuntimeException(TRACE_INFO,
 			"GpuStorageNode: not connected!\n");
 
-	uint32_t nwords = _backend->word_pool_count();
-	if (0 == nwords) return;
-
-	std::vector<uint64_t> hashes(nwords);
-	std::vector<double> counts(nwords);
-	std::vector<double> marginals(nwords);
-	_backend->word_read_bulk(nwords, hashes.data(),
-		counts.data(), marginals.data());
-
-	std::lock_guard<std::mutex> lk(_name_mtx);
-	for (uint32_t i = 0; i < nwords; i++)
-	{
-		auto it = _hash_to_name.find(hashes[i]);
-		if (it == _hash_to_name.end()) continue;
-
-		std::string name = it->second;
-		Handle h = as->add_node(SCHEMA_NODE, std::move(name));
-		if (counts[i] != 0.0 or marginals[i] != 0.0)
-		{
-			std::vector<double> vals = {counts[i], marginals[i]};
-			h->setValue(truth_key(), createFloatValue(vals));
-		}
-	}
+	// Load all node types first (needed as outgoing atoms for links),
+	// then load all link types.
+	loadType(as, NODE);
+	loadType(as, LINK);
 }
 
 void GpuStorageNode::storeAtomSpace(const AtomSpace* as)
@@ -629,13 +812,30 @@ std::string GpuStorageNode::monitor(void)
 }
 
 // ==============================================================
-// Phase 2: runQuery (stub)
+// Phase 2: runQuery
+//
+// Delegates to the BackingStore default implementation, which uses
+// our fetchIncomingByType() callback during pattern matching.
+// We only add a cache check: if the result is already cached
+// and fresh==false, skip re-execution.
 
 void GpuStorageNode::runQuery(const Handle& query, const Handle& key,
                               const Handle& metadata_key, bool fresh)
 {
-	throw RuntimeException(TRACE_INFO,
-		"GpuStorageNode::runQuery() not yet implemented (Phase 2)\n");
+	if (not _connected)
+		throw RuntimeException(TRACE_INFO,
+			"GpuStorageNode: not connected!\n");
+
+	// Cache check: if result already exists and not forced fresh
+	if (not fresh)
+	{
+		ValuePtr vp = query->getValue(key);
+		if (vp) return;
+	}
+
+	// Delegate to base class — it uses our fetchIncomingByType
+	// during pattern matching graph crawl.
+	BackingStore::runQuery(query, key, metadata_key, fresh);
 }
 
 // ==============================================================

--- a/opencog/persist/gpu/GpuStorageNode.h
+++ b/opencog/persist/gpu/GpuStorageNode.h
@@ -55,10 +55,23 @@ private:
 	std::unique_ptr<GpuBackend> _backend;
 	bool _connected;
 
-	// CPU-side name->hash mapping (GPU stores hashes, CPU knows strings)
+	// CPU-side (type,name)->hash mapping (GPU stores hashes, CPU knows strings)
+	struct TypedName {
+		Type type;
+		std::string name;
+		bool operator==(const TypedName& o) const {
+			return type == o.type && name == o.name;
+		}
+	};
+	struct TypedNameHash {
+		size_t operator()(const TypedName& tn) const {
+			return std::hash<std::string>()(tn.name)
+			     ^ (size_t(tn.type) * 0x9E3779B97F4A7C15ULL);
+		}
+	};
 	std::mutex _name_mtx;
-	std::unordered_map<std::string, uint64_t> _name_to_hash;
-	std::unordered_map<uint64_t, std::string> _hash_to_name;
+	std::unordered_map<TypedName, uint64_t, TypedNameHash> _name_to_hash;
+	std::unordered_map<uint64_t, TypedName> _hash_to_name;
 
 	// Atom->GPU-index mapping for Values
 	struct ValueSlot {
@@ -71,10 +84,11 @@ private:
 	// Internal helpers
 	void parse_uri(void);
 
-	uint64_t name_hash(const std::string& name);
-	uint32_t store_word(const std::string& name);
-	uint32_t store_pair(uint32_t word_a, uint32_t word_b);
-	uint32_t lookup_word(const std::string& name);
+	uint64_t name_hash(Type t, const std::string& name);
+	uint32_t store_word(Type t, const std::string& name);
+	uint32_t store_pair(uint32_t word_a, uint32_t word_b,
+	                    Type link_type);
+	uint32_t lookup_word(Type t, const std::string& name);
 	uint32_t lookup_pair(uint32_t word_a, uint32_t word_b);
 
 	void store_node_values(const Handle&, uint32_t pool_idx);

--- a/opencog/persist/gpu/OpenCLBackend.cc
+++ b/opencog/persist/gpu/OpenCLBackend.cc
@@ -12,6 +12,7 @@
 
 #include <fstream>
 #include <sstream>
+#include <vector>
 
 #include <opencog/util/exceptions.h>
 #include <opencog/util/Logger.h>
@@ -79,7 +80,7 @@ void OpenCLBackend::compile_kernels()
 	     << " -D PAIR_HT_CAPACITY=" << GPU_PAIR_HT_CAPACITY
 	     << " -D SECTION_HT_CAPACITY=" << GPU_SECTION_HT_CAPACITY;
 
-	std::string ht_src, as_src;
+	std::string ht_src, as_src, inc_src;
 	std::vector<std::string> search_paths = {
 		"/usr/local/share/opencog/opencl/gpu/",
 		"/usr/share/opencog/opencl/gpu/",
@@ -91,7 +92,8 @@ void OpenCLBackend::compile_kernels()
 
 	for (const auto& prefix : search_paths)
 	{
-		if (not ht_src.empty() and not as_src.empty()) break;
+		if (not ht_src.empty() and not as_src.empty()
+		    and not inc_src.empty()) break;
 
 		if (ht_src.empty())
 		{
@@ -107,6 +109,13 @@ void OpenCLBackend::compile_kernels()
 				as_src.assign(std::istreambuf_iterator<char>(f),
 				              std::istreambuf_iterator<char>());
 		}
+		if (inc_src.empty())
+		{
+			std::ifstream f(prefix + "gpu-incoming.cl");
+			if (f.is_open())
+				inc_src.assign(std::istreambuf_iterator<char>(f),
+				              std::istreambuf_iterator<char>());
+		}
 	}
 
 	if (ht_src.empty() or as_src.empty())
@@ -115,6 +124,8 @@ void OpenCLBackend::compile_kernels()
 			"or gpu-atomspace.cl kernel source files\n");
 
 	std::string combined = ht_src + "\n" + as_src;
+	if (not inc_src.empty())
+		combined += "\n" + inc_src;
 
 	cl::Program::Sources sources;
 	sources.push_back(combined);
@@ -172,6 +183,8 @@ void OpenCLBackend::alloc_pools()
 		sizeof(cl_double) * GPU_WORD_CAPACITY);
 	_word_class_id = cl::Buffer(_context, CL_MEM_READ_WRITE,
 		sizeof(cl_uint) * GPU_WORD_CAPACITY);
+	_word_type = cl::Buffer(_context, CL_MEM_READ_WRITE,
+		sizeof(cl_ushort) * GPU_WORD_CAPACITY);
 	_word_next_free = cl::Buffer(_context, CL_MEM_READ_WRITE,
 		sizeof(cl_uint));
 
@@ -220,6 +233,13 @@ void OpenCLBackend::init_pools()
 	_queue.enqueueWriteBuffer(_word_next_free, CL_TRUE, 0, sizeof(cl_uint), &zero);
 	_queue.enqueueWriteBuffer(_pair_next_free, CL_TRUE, 0, sizeof(cl_uint), &zero);
 	_queue.enqueueWriteBuffer(_sec_next_free, CL_TRUE, 0, sizeof(cl_uint), &zero);
+
+	// Zero out word type array
+	{
+		std::vector<cl_ushort> zt(GPU_WORD_CAPACITY, 0);
+		_queue.enqueueWriteBuffer(_word_type, CL_TRUE, 0,
+			sizeof(cl_ushort) * GPU_WORD_CAPACITY, zt.data());
+	}
 
 	// Initialize hash table keys to EMPTY, values to EMPTY.
 	// Use CL_TRUE (blocking) because host vectors go out of scope.
@@ -336,6 +356,21 @@ void OpenCLBackend::word_read_values(uint32_t idx,
 	marginal = m;
 }
 
+void OpenCLBackend::word_write_type(uint32_t idx, uint16_t type)
+{
+	cl_ushort v = type;
+	_queue.enqueueWriteBuffer(_word_type, CL_TRUE,
+		sizeof(cl_ushort) * idx, sizeof(cl_ushort), &v);
+}
+
+uint16_t OpenCLBackend::word_read_type(uint32_t idx)
+{
+	cl_ushort v = 0;
+	_queue.enqueueReadBuffer(_word_type, CL_TRUE,
+		sizeof(cl_ushort) * idx, sizeof(cl_ushort), &v);
+	return (uint16_t)v;
+}
+
 void OpenCLBackend::word_delete(uint64_t nhash)
 {
 	cl::Kernel kern(_program, "ht_delete");
@@ -362,7 +397,8 @@ uint32_t OpenCLBackend::word_pool_count()
 }
 
 void OpenCLBackend::word_read_bulk(uint32_t n, uint64_t* hashes,
-                                   double* counts, double* marginals)
+                                   double* counts, double* marginals,
+                                   uint16_t* types)
 {
 	_queue.enqueueReadBuffer(_word_name_hash, CL_TRUE, 0,
 		sizeof(cl_ulong) * n, hashes);
@@ -370,6 +406,8 @@ void OpenCLBackend::word_read_bulk(uint32_t n, uint64_t* hashes,
 		sizeof(cl_double) * n, counts);
 	_queue.enqueueReadBuffer(_word_mi_marginal, CL_TRUE, 0,
 		sizeof(cl_double) * n, marginals);
+	_queue.enqueueReadBuffer(_word_type, CL_TRUE, 0,
+		sizeof(cl_ushort) * n, types);
 }
 
 // ==============================================================
@@ -460,11 +498,105 @@ void OpenCLBackend::pair_read_values(uint32_t idx,
 	mi = m;
 }
 
+void OpenCLBackend::pair_write_type(uint32_t idx, uint16_t type)
+{
+	cl_uint val = (cl_uint)type;
+	_queue.enqueueWriteBuffer(_pair_flags, CL_TRUE,
+		sizeof(cl_uint) * idx, sizeof(cl_uint), &val);
+}
+
+uint16_t OpenCLBackend::pair_read_type(uint32_t idx)
+{
+	cl_uint val = 0;
+	_queue.enqueueReadBuffer(_pair_flags, CL_TRUE,
+		sizeof(cl_uint) * idx, sizeof(cl_uint), &val);
+	return (uint16_t)val;
+}
+
 uint32_t OpenCLBackend::pair_pool_count()
 {
 	cl_uint cnt = 0;
 	_queue.enqueueReadBuffer(_pair_next_free, CL_TRUE, 0, sizeof(cl_uint), &cnt);
 	return cnt;
+}
+
+// ==============================================================
+// Incoming-set scan (Phase 2)
+
+uint32_t OpenCLBackend::incoming_scan(uint32_t target_word_idx,
+                                       uint32_t* out_pair_indices,
+                                       uint32_t max_results)
+{
+	uint32_t pool_count = pair_pool_count();
+	if (pool_count == 0) return 0;
+
+	cl::Kernel kern(_program, "incoming_scan");
+
+	// Output buffers
+	cl::Buffer match_buf(_context, CL_MEM_WRITE_ONLY,
+		sizeof(cl_uint) * max_results);
+	cl::Buffer count_buf(_context, CL_MEM_READ_WRITE, sizeof(cl_uint));
+
+	// Initialize match count to zero
+	cl_uint zero = 0;
+	_queue.enqueueWriteBuffer(count_buf, CL_TRUE, 0, sizeof(cl_uint), &zero);
+
+	kern.setArg(0, _pair_word_a);
+	kern.setArg(1, _pair_word_b);
+	kern.setArg(2, (cl_uint)target_word_idx);
+	kern.setArg(3, (cl_uint)pool_count);
+	kern.setArg(4, match_buf);
+	kern.setArg(5, count_buf);
+	kern.setArg(6, (cl_uint)max_results);
+
+	// Launch one thread per pair slot
+	size_t global_size = ((pool_count + 255) / 256) * 256;
+	_queue.enqueueNDRangeKernel(kern, cl::NullRange,
+		cl::NDRange(global_size), cl::NDRange(256));
+
+	// Read back match count
+	cl_uint match_count = 0;
+	_queue.enqueueReadBuffer(count_buf, CL_TRUE, 0,
+		sizeof(cl_uint), &match_count);
+
+	if (match_count > max_results)
+		match_count = max_results;
+
+	if (match_count > 0)
+	{
+		_queue.enqueueReadBuffer(match_buf, CL_TRUE, 0,
+			sizeof(cl_uint) * match_count, out_pair_indices);
+	}
+
+	return match_count;
+}
+
+uint32_t OpenCLBackend::pair_read_bulk(uint32_t n,
+                                       uint32_t* word_a, uint32_t* word_b,
+                                       double* counts, double* mis,
+                                       uint16_t* types)
+{
+	uint32_t pool_count = pair_pool_count();
+	if (pool_count == 0) return 0;
+	if (n > pool_count) n = pool_count;
+
+	_queue.enqueueReadBuffer(_pair_word_a, CL_TRUE, 0,
+		sizeof(cl_uint) * n, word_a);
+	_queue.enqueueReadBuffer(_pair_word_b, CL_TRUE, 0,
+		sizeof(cl_uint) * n, word_b);
+	_queue.enqueueReadBuffer(_pair_count, CL_TRUE, 0,
+		sizeof(cl_double) * n, counts);
+	_queue.enqueueReadBuffer(_pair_mi, CL_TRUE, 0,
+		sizeof(cl_double) * n, mis);
+
+	// Read pair flags and convert uint32_t -> uint16_t types
+	std::vector<cl_uint> flags(n);
+	_queue.enqueueReadBuffer(_pair_flags, CL_TRUE, 0,
+		sizeof(cl_uint) * n, flags.data());
+	for (uint32_t i = 0; i < n; i++)
+		types[i] = (uint16_t)flags[i];
+
+	return n;
 }
 
 // ==============================================================

--- a/opencog/persist/gpu/OpenCLBackend.h
+++ b/opencog/persist/gpu/OpenCLBackend.h
@@ -33,6 +33,7 @@ private:
 	cl::Buffer _word_count;        // double[WORD_CAPACITY]
 	cl::Buffer _word_mi_marginal;  // double[WORD_CAPACITY]
 	cl::Buffer _word_class_id;     // uint[WORD_CAPACITY]
+	cl::Buffer _word_type;         // ushort[WORD_CAPACITY]
 	cl::Buffer _word_next_free;    // uint[1]
 
 	// GPU SoA pool buffers -- PairPool
@@ -82,10 +83,13 @@ public:
 	void word_write_marginal(uint32_t idx, double marginal) override;
 	void word_read_values(uint32_t idx,
 	                      double& count, double& marginal) override;
+	void word_write_type(uint32_t idx, uint16_t type) override;
+	uint16_t word_read_type(uint32_t idx) override;
 	void word_delete(uint64_t name_hash) override;
 	uint32_t word_pool_count() override;
 	void word_read_bulk(uint32_t n, uint64_t* hashes,
-	                    double* counts, double* marginals) override;
+	                    double* counts, double* marginals,
+	                    uint16_t* types) override;
 
 	uint32_t pair_find_or_create(uint32_t word_a,
 	                             uint32_t word_b) override;
@@ -94,9 +98,19 @@ public:
 	void pair_write_mi(uint32_t idx, double mi) override;
 	void pair_read_values(uint32_t idx,
 	                      double& count, double& mi) override;
+	void pair_write_type(uint32_t idx, uint16_t type) override;
+	uint16_t pair_read_type(uint32_t idx) override;
 	uint32_t pair_pool_count() override;
 
 	uint32_t section_pool_count() override;
+
+	uint32_t incoming_scan(uint32_t target_word_idx,
+	                       uint32_t* out_pair_indices,
+	                       uint32_t max_results) override;
+	uint32_t pair_read_bulk(uint32_t n,
+	                        uint32_t* word_a, uint32_t* word_b,
+	                        double* counts, double* mis,
+	                        uint16_t* types) override;
 
 	void barrier() override;
 };

--- a/tests/persist/gpu/BasicSaveUTest.cxxtest
+++ b/tests/persist/gpu/BasicSaveUTest.cxxtest
@@ -1,0 +1,384 @@
+/*
+ * tests/persist/gpu/BasicSaveUTest.cxxtest
+ *
+ * Most basic, simplest sniff test, saves and restores a few atoms.
+ * Adapted from tests/persist/rocks/BasicSaveUTest.cxxtest.
+ *
+ * The GPU backend supports SCHEMA_NODE (word pool) and binary
+ * LIST_LINK (pair pool). The Rocks version uses CONCEPT_NODE,
+ * NUMBER_NODE, and 4-arity SET_LINK; those are adapted here
+ * for GPU constraints.
+ *
+ * GPU storage is volatile (in-memory), so test_table verifies
+ * storeAtomSpace + loadAtomSpace within a single connection,
+ * rather than across close/reopen.
+ *
+ * Copyright (C) 2008, 2009, 2019 Linas Vepstas <linasvepstas@gmail.com>
+ * Copyright (C) 2025 OpenCog Foundation
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#include <cstdio>
+
+#include <opencog/atoms/base/Atom.h>
+#include <opencog/atoms/base/Link.h>
+#include <opencog/atoms/base/Node.h>
+#include <opencog/atoms/atom_types/atom_types.h>
+#include <opencog/atoms/value/FloatValue.h>
+#include <opencog/atoms/value/VoidValue.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/persist/gpu/GpuStorageNode.h>
+#include <opencog/persist/gpu-types/atom_types.h>
+
+#include <opencog/util/Logger.h>
+
+using namespace opencog;
+
+class BasicSaveUTest : public CxxTest::TestSuite
+{
+	private:
+		std::string uri;
+
+		// Per-table-row atoms: 2 nodes + 1 binary link
+		Handle n1[10];
+		Handle n2[10];
+		Handle   l[10];
+		Handle a1[10];
+		Handle a2[10];
+		Handle al[10];
+
+	public:
+		BasicSaveUTest(void)
+		{
+			logger().set_level(Logger::INFO);
+			// logger().set_level(Logger::DEBUG);
+			logger().set_print_to_stdout_flag(true);
+			logger().set_sync_flag(true);
+
+			uri = "gpu://:";
+		}
+
+		~BasicSaveUTest() {}
+
+		void setUp(void) {}
+		void tearDown(void) {}
+
+		void single_atom_save_restore(std::string id);
+		void add_to_table(int, AtomSpace*, std::string id);
+		void check_table(int, AtomSpace*, std::string id);
+
+		void test_single_atom(void);
+		void test_fresh_atom(void);
+		void test_table(void);
+};
+
+// ============================================================
+
+static void atomCompare(Handle a, Handle b, const char* where)
+{
+	printf("Testing at %s\n", where);
+	TSM_ASSERT("No atom found", b != nullptr);
+	if (nullptr == b) return;
+
+	TSM_ASSERT_EQUALS("Type mismatch", a->get_type(), b->get_type());
+
+	NodePtr na(NodeCast(a));
+	NodePtr nb(NodeCast(b));
+	if (na and nb)
+	{
+		TSM_ASSERT_EQUALS("Name mismatch", na->get_name(), nb->get_name());
+	}
+
+	LinkPtr la(LinkCast(a));
+	LinkPtr lb(LinkCast(b));
+	if (la and lb)
+	{
+		TSM_ASSERT_EQUALS("Arity mismatch", la->get_arity(), lb->get_arity());
+		if (*la != *lb)
+		{
+			printf("Mismatching la = %s\n", la->to_string().c_str());
+			printf("Mismatching lb = %s\n", lb->to_string().c_str());
+			TSM_ASSERT_EQUALS("Link mis-match", la, lb);
+		}
+	}
+
+	ValuePtr ta = a->getValue(truth_key());
+	ValuePtr tb = b->getValue(truth_key());
+	if (ta or tb)
+	{
+		TSM_ASSERT("Missing truth value", ta);
+		TSM_ASSERT("Missing truth value", tb);
+		if (ta and tb)
+		{
+			TSM_ASSERT("Truth value miscompare", (*ta)==(*tb));
+
+			if (not ((*ta) == (*tb)))
+			{
+				FloatValuePtr fva = FloatValueCast(ta);
+				FloatValuePtr fvb = FloatValueCast(tb);
+				fprintf(stderr,
+					"Error, truth value miscompare, ma=%18.16g\n"
+					"                               mb=%18.16g\n"
+					"   mdiff=%g ca=%g cb=%g\n",
+					fva->value()[0], fvb->value()[0],
+					fva->value()[0] - fvb->value()[0],
+					fva->value()[1], fvb->value()[1]);
+				fprintf(stderr, "Above is for %s\n\n",
+					a->to_string().c_str());
+			}
+		}
+	}
+}
+
+// ============================================================
+/**
+ * A simple test case that tests the save and restore of
+ * a couple of nodes and a link. Does not test atomtable/atomspace
+ * at all.
+ *
+ * Uses the message-based open/close mechanism, exactly as
+ * the Rocks and Cog StorageNode tests do.
+ */
+void BasicSaveUTest::single_atom_save_restore(std::string id)
+{
+	AtomSpacePtr as = createAtomSpace();
+	Handle hsn = as->add_node(GPU_STORAGE_NODE, std::string(uri));
+	GpuStorageNodePtr store = GpuStorageNodeCast(hsn);
+	logger().debug("single_atom_save_restore: create %p", store.get());
+
+	// Open via message-based API (canonical StorageNode pattern)
+	store->setValue(as->add_node(PREDICATE_NODE, "*-open-*"),
+	                createVoidValue());
+	logger().debug("single_atom_save_restore: opened");
+
+	if (!store->connected())
+	{
+		logger().debug("single_atom_save_restore: cannot connect to GPU");
+		TSM_ASSERT("cannot connect to GPU", false);
+		return;
+	}
+	logger().debug("single_atom_save_restore: connected");
+
+	// Create an atom ...
+	Handle a(createNode(SCHEMA_NODE, id + "someNode"));
+	ValuePtr stv(createFloatValue(
+		std::vector<double>({0.55, 0.6})));
+	a->setValue(truth_key(), stv);
+
+	Handle h = a->get_handle();
+	TSM_ASSERT("Bad Handle", nullptr != h);
+
+	// Store the atom ...
+	store->storeAtom(h, true);
+	store->barrier();
+	printf("Done storing single node\n");
+	fflush(stdout);
+
+	// Fetch it back ...
+	std::string nam = id + "someNode";
+	Handle b = createNode(SCHEMA_NODE, nam);
+	logger().debug("single_atom_save_restore: try to get schema=%s",
+		b->to_string().c_str());
+	store->getAtom(b);
+	logger().debug("single_atom_save_restore: Got the schema=%s",
+		b->to_string().c_str());
+	printf("Done fetching single node\n");
+	fflush(stdout);
+
+	// Are they equal ??
+	atomCompare(a, b, "Single node save-restore");
+
+	// Create a second atom, connect it to the first
+	// with a link. Save it, fetch it ... are they equal?
+	Handle a2(createNode(SCHEMA_NODE, id + "otherNode"));
+	store->storeAtom(a2->get_handle(), true);
+
+	HandleSeq hvec;
+	hvec.push_back(a->get_handle());
+	hvec.push_back(a2->get_handle());
+
+	Handle lnk(createLink(hvec, LIST_LINK));
+	store->storeAtom(lnk->get_handle(), true);
+	store->barrier();
+	printf("Done storing single link\n");
+	fflush(stdout);
+
+	Handle hl(createLink(LIST_LINK, a->get_handle(), a2->get_handle()));
+	store->getAtom(hl);
+	atomCompare(lnk, hl, "Single link save-restore");
+	printf("Done fetching single link\n");
+	fflush(stdout);
+
+	// Clean up: erase GPU pools and close via message
+	store->erase();
+	store->setValue(as->add_node(PREDICATE_NODE, "*-close-*"),
+	                createVoidValue());
+}
+
+// ============================================================
+
+void BasicSaveUTest::add_to_table(int idx, AtomSpace *table,
+                                  std::string id)
+{
+	// Create two nodes with truth values ...
+	n1[idx] = createNode(SCHEMA_NODE, id + "fromNode");
+	ValuePtr stv(createFloatValue(
+		std::vector<double>({0.11, 1.0 / (100.0 + idx)})));
+	n1[idx]->setValue(truth_key(), stv);
+	n1[idx] = table->add_atom(n1[idx]);
+	a1[idx] = n1[idx];
+
+	n2[idx] = createNode(SCHEMA_NODE, id + "toNode");
+	ValuePtr stv2(createFloatValue(
+		std::vector<double>({0.22, 1.0 / (200.0 + idx)})));
+	n2[idx]->setValue(truth_key(), stv2);
+	n2[idx] = table->add_atom(n2[idx]);
+	a2[idx] = n2[idx];
+
+	// Create a binary link between them (with truth value).
+	// The Rocks test uses a 4-arity SET_LINK with NumberNode;
+	// GPU pools only support binary LIST_LINK between SchemaNodes.
+	HandleSeq hvec;
+	hvec.push_back(a1[idx]->get_handle());
+	hvec.push_back(a2[idx]->get_handle());
+
+	l[idx] = createLink(hvec, LIST_LINK);
+	ValuePtr stv3(createFloatValue(
+		std::vector<double>({(idx + 1) * 1.5, (idx + 1) * 0.3})));
+	l[idx]->setValue(truth_key(), stv3);
+	l[idx] = table->add_atom(l[idx]);
+	al[idx] = l[idx];
+}
+
+void BasicSaveUTest::check_table(int idx, AtomSpace *table,
+                                 std::string id)
+{
+	Handle hb1 = table->get_atom(Handle(n1[idx]));
+	atomCompare(a1[idx], hb1, "check_table hb1");
+
+	Handle hb2 = table->get_atom(Handle(n2[idx]));
+	atomCompare(a2[idx], hb2, "check_table hb2");
+
+	HandleSeq hvec;
+	hvec.push_back(hb1);
+	hvec.push_back(hb2);
+
+	Handle lb(createLink(hvec, LIST_LINK));
+	Handle hlb = table->get_atom(lb);
+	atomCompare(al[idx], hlb, "check_table hlb");
+}
+
+// ============================================================
+
+void BasicSaveUTest::test_single_atom(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	single_atom_save_restore("aaa ");
+	single_atom_save_restore("bbb ");
+	single_atom_save_restore("ccc ");
+	single_atom_save_restore("ddd ");
+	single_atom_save_restore("eee ");
+	single_atom_save_restore("$$$ ");
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void BasicSaveUTest::test_fresh_atom(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	AtomSpacePtr as = createAtomSpace();
+	Handle hsn = as->add_node(GPU_STORAGE_NODE, std::string(uri));
+	GpuStorageNodePtr store = GpuStorageNodeCast(hsn);
+	store->open();
+
+	if (!store->connected())
+	{
+		logger().debug("test_fresh_atom: cannot connect to GPU");
+		return;
+	}
+
+	Handle ha(createNode(SCHEMA_NODE, "electrical"));
+	Handle hb(createNode(SCHEMA_NODE, "energy"));
+
+	// Store a ListLink with truth value.
+	Handle lf(createLink(LIST_LINK, ha, hb));
+	lf->setValue(truth_key(), createFloatValue(
+		std::vector<double>({0.55, 0.6})));
+	store->storeAtom(lf, true);
+	store->barrier();
+
+	// Fetch it back.
+	Handle hf(createLink(LIST_LINK, ha, hb));
+	store->getAtom(hf);
+	atomCompare(lf, hf, "Fully Fresh");
+
+	store->erase();
+	store->close();
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void BasicSaveUTest::test_table()
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	// Create store in its own AtomSpace (so data AtomSpace is clean)
+	AtomSpacePtr store_as = createAtomSpace();
+	Handle hsn = store_as->add_node(GPU_STORAGE_NODE, std::string(uri));
+	GpuStorageNodePtr store = GpuStorageNodeCast(hsn);
+	store->open();
+
+	if (!store->connected())
+	{
+		TSM_ASSERT("cannot connect to GPU", false);
+		return;
+	}
+
+	// Data AtomSpace: create atoms
+	AtomSpacePtr data_as = createAtomSpace();
+	AtomSpace *table1 = data_as.get();
+
+	int idx = 0;
+	add_to_table(idx++, table1, "AA-aa-wow ");
+	add_to_table(idx++, table1, "BB-bb-wow ");
+	add_to_table(idx++, table1, "CC-cc-wow ");
+	add_to_table(idx++, table1, "DD-dd-wow ");
+	add_to_table(idx++, table1, "EE-ee-wow ");
+
+	// Store everything to GPU
+	store->storeAtomSpace(table1);
+	store->barrier();
+	size_t num_stored = table1->get_size();
+	printf("Done storing table; size=%lu\n", num_stored);
+
+	// Load into a fresh AtomSpace from GPU
+	AtomSpacePtr load_as = createAtomSpace();
+	AtomSpace *table2 = load_as.get();
+
+	store->loadAtomSpace(table2);
+	store->barrier();
+	size_t num_fetched = table2->get_size();
+	printf("test_table: loaded %lu atoms from GPU, stored %lu\n",
+	       num_fetched, num_stored);
+
+	// We stored 5 x (2 nodes + 1 link) = 15 atoms.
+	// loadAtomSpace should recreate them all.
+	TSM_ASSERT("Too few atoms loaded", num_fetched >= num_stored);
+
+	// Verify each table row
+	idx = 0;
+	check_table(idx++, table2, "AA-aa-wow ");
+	check_table(idx++, table2, "BB-bb-wow ");
+	check_table(idx++, table2, "CC-cc-wow ");
+	check_table(idx++, table2, "DD-dd-wow ");
+	check_table(idx++, table2, "EE-ee-wow ");
+
+	store->erase();
+	store->close();
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/* ============================= END OF FILE ================= */

--- a/tests/persist/gpu/CMakeLists.txt
+++ b/tests/persist/gpu/CMakeLists.txt
@@ -10,3 +10,6 @@ LINK_LIBRARIES(
 )
 
 ADD_CXXTEST(GpuStorageNodeUTest)
+ADD_CXXTEST(GpuIncomingUTest)
+ADD_CXXTEST(BasicSaveUTest)
+ADD_CXXTEST(GpuBulkUTest)

--- a/tests/persist/gpu/GpuBulkUTest.cxxtest
+++ b/tests/persist/gpu/GpuBulkUTest.cxxtest
@@ -1,0 +1,574 @@
+/*
+ * tests/persist/gpu/GpuBulkUTest.cxxtest
+ *
+ * Multi-type correctness and GPU-scale showcase test.
+ * Verifies that atom Type is stored/retrieved correctly,
+ * that same-name-different-type atoms don't collide,
+ * and demonstrates GPU throughput at scale.
+ *
+ * Copyright (C) 2025 OpenCog Foundation
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#include <cstdio>
+#include <chrono>
+#include <sstream>
+
+#include <opencog/atoms/base/Atom.h>
+#include <opencog/atoms/base/Link.h>
+#include <opencog/atoms/base/Node.h>
+#include <opencog/atoms/atom_types/atom_types.h>
+#include <opencog/atoms/value/FloatValue.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/persist/gpu/GpuStorageNode.h>
+#include <opencog/persist/gpu-types/atom_types.h>
+
+#include <opencog/util/Logger.h>
+
+using namespace opencog;
+
+class GpuBulkUTest : public CxxTest::TestSuite
+{
+private:
+	std::string uri;
+
+public:
+	GpuBulkUTest(void)
+	{
+		logger().set_level(Logger::INFO);
+		logger().set_print_to_stdout_flag(true);
+		uri = "gpu://:";
+	}
+
+	~GpuBulkUTest() {}
+
+	void setUp(void) {}
+	void tearDown(void) {}
+
+	void test_multi_type_nodes(void);
+	void test_multi_type_links(void);
+	void test_type_collision_safety(void);
+	void test_bulk_store_load(void);
+	void test_incoming_at_scale(void);
+	void test_throughput(void);
+};
+
+// Helper: create FloatValue from two doubles
+static ValuePtr mk_tv(double a, double b)
+{
+	return createFloatValue(std::vector<double>({a, b}));
+}
+
+// ============================================================
+// Test 1: Store 500 each of CONCEPT/SCHEMA/PREDICATE nodes,
+// load back, verify types are preserved.
+
+void GpuBulkUTest::test_multi_type_nodes(void)
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	AtomSpacePtr as = createAtomSpace();
+	Handle hsn = as->add_node(GPU_STORAGE_NODE, std::string(uri));
+	GpuStorageNodePtr store = GpuStorageNodeCast(hsn);
+	store->open();
+	TSM_ASSERT("Cannot connect to GPU", store->connected());
+
+	const int N = 500;
+
+	// Store 500 of each type
+	for (int i = 0; i < N; i++)
+	{
+		std::string name = "node-" + std::to_string(i);
+
+		Handle hc = createNode(CONCEPT_NODE, name);
+		hc->setValue(truth_key(), mk_tv(1.0, (double)i));
+		store->storeAtom(hc, false);
+
+		Handle hs = createNode(SCHEMA_NODE, name);
+		hs->setValue(truth_key(), mk_tv(2.0, (double)i));
+		store->storeAtom(hs, false);
+
+		Handle hp = createNode(PREDICATE_NODE, name);
+		hp->setValue(truth_key(), mk_tv(3.0, (double)i));
+		store->storeAtom(hp, false);
+	}
+	store->barrier();
+
+	// Load into a fresh AtomSpace
+	AtomSpacePtr load_as = createAtomSpace();
+	store->loadAtomSpace(load_as.get());
+	store->barrier();
+
+	// Verify: should have 3*N nodes
+	size_t count = load_as->get_size();
+	printf("  Multi-type nodes: stored %d, loaded %lu\n", 3*N, count);
+	TSM_ASSERT_EQUALS("Node count mismatch", count, (size_t)(3*N));
+
+	// Spot-check types and values via get_atom
+	Handle chk_c = load_as->get_atom(createNode(CONCEPT_NODE, "node-42"));
+	TSM_ASSERT("Missing ConceptNode", chk_c != nullptr);
+	if (chk_c)
+	{
+		TSM_ASSERT_EQUALS("Wrong type", chk_c->get_type(), CONCEPT_NODE);
+		FloatValuePtr fv = FloatValueCast(chk_c->getValue(truth_key()));
+		TSM_ASSERT("Missing truth value", fv != nullptr);
+		if (fv)
+		{
+			TSM_ASSERT_DELTA("Bad count", fv->value()[0], 1.0, 1e-10);
+			TSM_ASSERT_DELTA("Bad marginal", fv->value()[1], 42.0, 1e-10);
+		}
+	}
+
+	Handle chk_s = load_as->get_atom(createNode(SCHEMA_NODE, "node-42"));
+	TSM_ASSERT("Missing SchemaNode", chk_s != nullptr);
+	if (chk_s)
+	{
+		TSM_ASSERT_EQUALS("Wrong type", chk_s->get_type(), SCHEMA_NODE);
+		FloatValuePtr fv = FloatValueCast(chk_s->getValue(truth_key()));
+		TSM_ASSERT("Missing truth value", fv != nullptr);
+		if (fv)
+			TSM_ASSERT_DELTA("Bad count", fv->value()[0], 2.0, 1e-10);
+	}
+
+	Handle chk_p = load_as->get_atom(createNode(PREDICATE_NODE, "node-42"));
+	TSM_ASSERT("Missing PredicateNode", chk_p != nullptr);
+	if (chk_p)
+	{
+		TSM_ASSERT_EQUALS("Wrong type", chk_p->get_type(), PREDICATE_NODE);
+		FloatValuePtr fv = FloatValueCast(chk_p->getValue(truth_key()));
+		TSM_ASSERT("Missing truth value", fv != nullptr);
+		if (fv)
+			TSM_ASSERT_DELTA("Bad count", fv->value()[0], 3.0, 1e-10);
+	}
+
+	store->erase();
+	store->close();
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// ============================================================
+// Test 2: Store LIST_LINK and SET_LINK pairs with DIFFERENT
+// outgoing nodes, verify types are preserved.
+//
+// Note: The GPU pair pool is keyed by (word_a, word_b) — one
+// slot per unique node pair. Different link types between the
+// same two nodes share a slot. This test uses distinct node
+// pairs for each link type to verify type round-trip.
+
+void GpuBulkUTest::test_multi_type_links(void)
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	AtomSpacePtr as = createAtomSpace();
+	Handle hsn = as->add_node(GPU_STORAGE_NODE, std::string(uri));
+	GpuStorageNodePtr store = GpuStorageNodeCast(hsn);
+	store->open();
+	TSM_ASSERT("Cannot connect to GPU", store->connected());
+
+	const int N = 200;
+
+	// LIST_LINKs: between "listA-i" and "listB-i"
+	for (int i = 0; i < N; i++)
+	{
+		Handle ha = createNode(SCHEMA_NODE,
+			"listA-" + std::to_string(i));
+		Handle hb = createNode(SCHEMA_NODE,
+			"listB-" + std::to_string(i));
+		Handle ll = createLink(LIST_LINK, ha, hb);
+		ll->setValue(truth_key(), mk_tv(1.0, (double)i));
+		store->storeAtom(ll, false);
+	}
+
+	// SET_LINKs: between "setA-i" and "setB-i" (different nodes)
+	for (int i = 0; i < N; i++)
+	{
+		Handle ha = createNode(SCHEMA_NODE,
+			"setA-" + std::to_string(i));
+		Handle hb = createNode(SCHEMA_NODE,
+			"setB-" + std::to_string(i));
+		Handle sl = createLink(SET_LINK, ha, hb);
+		sl->setValue(truth_key(), mk_tv(2.0, (double)i));
+		store->storeAtom(sl, false);
+	}
+	store->barrier();
+
+	// Load and verify
+	AtomSpacePtr load_as = createAtomSpace();
+	store->loadAtomSpace(load_as.get());
+	store->barrier();
+
+	// 4*N nodes (listA, listB, setA, setB) + 2*N links = 6*N
+	size_t count = load_as->get_size();
+	printf("  Multi-type links: expected %d, loaded %lu\n", 6*N, count);
+	TSM_ASSERT_EQUALS("Atom count mismatch", count, (size_t)(6*N));
+
+	// Check a LIST_LINK
+	Handle ha = load_as->get_atom(
+		createNode(SCHEMA_NODE, "listA-50"));
+	Handle hb = load_as->get_atom(
+		createNode(SCHEMA_NODE, "listB-50"));
+	TSM_ASSERT("Missing list node A", ha != nullptr);
+	TSM_ASSERT("Missing list node B", hb != nullptr);
+	if (ha and hb)
+	{
+		Handle ll = load_as->get_atom(createLink(LIST_LINK, ha, hb));
+		TSM_ASSERT("Missing LIST_LINK", ll != nullptr);
+		if (ll)
+		{
+			TSM_ASSERT_EQUALS("Wrong link type",
+				ll->get_type(), LIST_LINK);
+			FloatValuePtr fv = FloatValueCast(
+				ll->getValue(truth_key()));
+			TSM_ASSERT("Missing truth value", fv != nullptr);
+			if (fv)
+				TSM_ASSERT_DELTA("Bad count",
+					fv->value()[0], 1.0, 1e-10);
+		}
+	}
+
+	// Check a SET_LINK
+	Handle sa = load_as->get_atom(
+		createNode(SCHEMA_NODE, "setA-50"));
+	Handle sb = load_as->get_atom(
+		createNode(SCHEMA_NODE, "setB-50"));
+	TSM_ASSERT("Missing set node A", sa != nullptr);
+	TSM_ASSERT("Missing set node B", sb != nullptr);
+	if (sa and sb)
+	{
+		Handle sl = load_as->get_atom(createLink(SET_LINK, sa, sb));
+		TSM_ASSERT("Missing SET_LINK", sl != nullptr);
+		if (sl)
+		{
+			TSM_ASSERT_EQUALS("Wrong link type",
+				sl->get_type(), SET_LINK);
+			FloatValuePtr fv = FloatValueCast(
+				sl->getValue(truth_key()));
+			TSM_ASSERT("Missing truth value", fv != nullptr);
+			if (fv)
+				TSM_ASSERT_DELTA("Bad count",
+					fv->value()[0], 2.0, 1e-10);
+		}
+	}
+
+	store->erase();
+	store->close();
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// ============================================================
+// Test 3: CRITICAL -- proves the same-name-different-type
+// collision bug is fixed.
+
+void GpuBulkUTest::test_type_collision_safety(void)
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	AtomSpacePtr as = createAtomSpace();
+	Handle hsn = as->add_node(GPU_STORAGE_NODE, std::string(uri));
+	GpuStorageNodePtr store = GpuStorageNodeCast(hsn);
+	store->open();
+	TSM_ASSERT("Cannot connect to GPU", store->connected());
+
+	// Store ConceptNode "foo" with values {1.0, 2.0}
+	Handle hc = createNode(CONCEPT_NODE, "foo");
+	hc->setValue(truth_key(), mk_tv(1.0, 2.0));
+	store->storeAtom(hc, true);
+
+	// Store SchemaNode "foo" with values {3.0, 4.0}
+	Handle hs = createNode(SCHEMA_NODE, "foo");
+	hs->setValue(truth_key(), mk_tv(3.0, 4.0));
+	store->storeAtom(hs, true);
+
+	store->barrier();
+
+	// Fetch ConceptNode "foo" -- should have {1.0, 2.0}
+	Handle fc = createNode(CONCEPT_NODE, "foo");
+	store->getAtom(fc);
+	FloatValuePtr fvc = FloatValueCast(fc->getValue(truth_key()));
+	TSM_ASSERT("Missing ConceptNode truth value", fvc != nullptr);
+	if (fvc)
+	{
+		printf("  ConceptNode 'foo': count=%g marginal=%g\n",
+		       fvc->value()[0], fvc->value()[1]);
+		TSM_ASSERT_DELTA("ConceptNode count wrong", fvc->value()[0], 1.0, 1e-10);
+		TSM_ASSERT_DELTA("ConceptNode marginal wrong", fvc->value()[1], 2.0, 1e-10);
+	}
+
+	// Fetch SchemaNode "foo" -- should have {3.0, 4.0}
+	Handle fs = createNode(SCHEMA_NODE, "foo");
+	store->getAtom(fs);
+	FloatValuePtr fvs = FloatValueCast(fs->getValue(truth_key()));
+	TSM_ASSERT("Missing SchemaNode truth value", fvs != nullptr);
+	if (fvs)
+	{
+		printf("  SchemaNode 'foo': count=%g marginal=%g\n",
+		       fvs->value()[0], fvs->value()[1]);
+		TSM_ASSERT_DELTA("SchemaNode count wrong", fvs->value()[0], 3.0, 1e-10);
+		TSM_ASSERT_DELTA("SchemaNode marginal wrong", fvs->value()[1], 4.0, 1e-10);
+	}
+
+	// Also verify they loaded back as distinct atoms
+	AtomSpacePtr load_as = createAtomSpace();
+	store->loadAtomSpace(load_as.get());
+	size_t count = load_as->get_size();
+	printf("  Collision safety: loaded %lu atoms (should be 2)\n", count);
+	TSM_ASSERT_EQUALS("Should have 2 distinct atoms", count, 2UL);
+
+	Handle lc = load_as->get_atom(createNode(CONCEPT_NODE, "foo"));
+	Handle ls = load_as->get_atom(createNode(SCHEMA_NODE, "foo"));
+	TSM_ASSERT("Missing ConceptNode after load", lc != nullptr);
+	TSM_ASSERT("Missing SchemaNode after load", ls != nullptr);
+	TSM_ASSERT("Should be different atoms!", lc != ls);
+
+	store->erase();
+	store->close();
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// ============================================================
+// Test 4: Store 10K nodes + 5K pairs, storeAtomSpace -> loadAtomSpace.
+
+void GpuBulkUTest::test_bulk_store_load(void)
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	AtomSpacePtr as = createAtomSpace();
+	Handle hsn = as->add_node(GPU_STORAGE_NODE, std::string(uri));
+	GpuStorageNodePtr store = GpuStorageNodeCast(hsn);
+	store->open();
+	TSM_ASSERT("Cannot connect to GPU", store->connected());
+
+	const int NNODES = 500;
+	const int NPAIRS = 250;
+
+	// Create data AtomSpace with many atoms
+	AtomSpacePtr data_as = createAtomSpace();
+	AtomSpace* dat = data_as.get();
+
+	for (int i = 0; i < NNODES; i++)
+	{
+		Handle h = dat->add_node(CONCEPT_NODE,
+			"bulk-" + std::to_string(i));
+		h->setValue(truth_key(), mk_tv((double)i, (double)(i * 0.1)));
+	}
+
+	for (int i = 0; i < NPAIRS; i++)
+	{
+		Handle ha = dat->add_node(CONCEPT_NODE,
+			"bulk-" + std::to_string(i * 2));
+		Handle hb = dat->add_node(CONCEPT_NODE,
+			"bulk-" + std::to_string(i * 2 + 1));
+		Handle lnk = dat->add_link(LIST_LINK, ha, hb);
+		lnk->setValue(truth_key(), mk_tv((double)i, (double)(i + 1)));
+	}
+
+	auto t0 = std::chrono::high_resolution_clock::now();
+	store->storeAtomSpace(dat);
+	store->barrier();
+	auto t1 = std::chrono::high_resolution_clock::now();
+
+	double store_ms = std::chrono::duration<double, std::milli>(t1-t0).count();
+	printf("  Bulk store: %d nodes + %d pairs in %.1f ms\n",
+	       NNODES, NPAIRS, store_ms);
+
+	// Load into fresh AtomSpace
+	AtomSpacePtr load_as = createAtomSpace();
+	auto t2 = std::chrono::high_resolution_clock::now();
+	store->loadAtomSpace(load_as.get());
+	store->barrier();
+	auto t3 = std::chrono::high_resolution_clock::now();
+
+	double load_ms = std::chrono::duration<double, std::milli>(t3-t2).count();
+	size_t loaded = load_as->get_size();
+	size_t expected = dat->get_size();
+	printf("  Bulk load: %lu atoms in %.1f ms (expected %lu)\n",
+	       loaded, load_ms, expected);
+
+	TSM_ASSERT_EQUALS("Atom count mismatch", loaded, expected);
+
+	// Spot-check a value
+	Handle chk = load_as->get_atom(createNode(CONCEPT_NODE, "bulk-42"));
+	TSM_ASSERT("Missing spot-check node", chk != nullptr);
+	if (chk)
+	{
+		FloatValuePtr fv = FloatValueCast(chk->getValue(truth_key()));
+		TSM_ASSERT("Missing truth value", fv != nullptr);
+		if (fv)
+		{
+			TSM_ASSERT_DELTA("Bad count", fv->value()[0], 42.0, 1e-10);
+		}
+	}
+
+	store->erase();
+	store->close();
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// ============================================================
+// Test 5: Hub node with 100 LIST_LINK + 100 SET_LINK pairs;
+// fetchIncomingByType correctly filters by link type.
+//
+// Uses different spoke nodes for each link type to avoid
+// pair-pool key collisions (one slot per node pair).
+
+void GpuBulkUTest::test_incoming_at_scale(void)
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	AtomSpacePtr as = createAtomSpace();
+	Handle hsn = as->add_node(GPU_STORAGE_NODE, std::string(uri));
+	GpuStorageNodePtr store = GpuStorageNodeCast(hsn);
+	store->open();
+	TSM_ASSERT("Cannot connect to GPU", store->connected());
+
+	const int N = 100;
+
+	// Create hub node
+	Handle hub = createNode(CONCEPT_NODE, "hub");
+	store->storeAtom(hub, false);
+
+	// Store N LIST_LINKs: hub <-> list-spoke-i
+	for (int i = 0; i < N; i++)
+	{
+		Handle spoke = createNode(CONCEPT_NODE,
+			"list-spoke-" + std::to_string(i));
+		store->storeAtom(spoke, false);
+
+		Handle ll = createLink(LIST_LINK, hub, spoke);
+		ll->setValue(truth_key(), mk_tv(1.0, (double)i));
+		store->storeAtom(ll, false);
+	}
+
+	// Store N SET_LINKs: hub <-> set-spoke-i (different nodes!)
+	for (int i = 0; i < N; i++)
+	{
+		Handle spoke = createNode(CONCEPT_NODE,
+			"set-spoke-" + std::to_string(i));
+		store->storeAtom(spoke, false);
+
+		Handle sl = createLink(SET_LINK, hub, spoke);
+		sl->setValue(truth_key(), mk_tv(2.0, (double)i));
+		store->storeAtom(sl, false);
+	}
+	store->barrier();
+
+	// fetchIncomingByType for LIST_LINK only
+	AtomSpacePtr list_as = createAtomSpace();
+	Handle list_hub = list_as->add_node(CONCEPT_NODE, "hub");
+	store->fetchIncomingByType(list_as.get(), list_hub, LIST_LINK);
+	store->barrier();
+
+	printf("  Incoming LIST_LINK: total atoms %lu\n", list_as->get_size());
+
+	HandleSeq ll_links;
+	list_as->get_handles_by_type(ll_links, LIST_LINK);
+	printf("  LIST_LINKs found: %lu (expected %d)\n",
+		ll_links.size(), N);
+	TSM_ASSERT_EQUALS("LIST_LINK count wrong",
+		ll_links.size(), (size_t)N);
+
+	HandleSeq sl_links;
+	list_as->get_handles_by_type(sl_links, SET_LINK);
+	printf("  SET_LINKs found: %lu (expected 0)\n", sl_links.size());
+	TSM_ASSERT_EQUALS("SET_LINKs should be filtered",
+		sl_links.size(), 0UL);
+
+	// fetchIncomingByType for SET_LINK only
+	AtomSpacePtr set_as = createAtomSpace();
+	Handle set_hub = set_as->add_node(CONCEPT_NODE, "hub");
+	store->fetchIncomingByType(set_as.get(), set_hub, SET_LINK);
+	store->barrier();
+
+	HandleSeq sl_links2;
+	set_as->get_handles_by_type(sl_links2, SET_LINK);
+	printf("  SET_LINKs (filtered): %lu (expected %d)\n",
+		sl_links2.size(), N);
+	TSM_ASSERT_EQUALS("SET_LINK count wrong",
+		sl_links2.size(), (size_t)N);
+
+	store->erase();
+	store->close();
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// ============================================================
+// Test 6: Throughput showcase -- print wall-clock numbers.
+
+void GpuBulkUTest::test_throughput(void)
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	AtomSpacePtr as = createAtomSpace();
+	Handle hsn = as->add_node(GPU_STORAGE_NODE, std::string(uri));
+	GpuStorageNodePtr store = GpuStorageNodeCast(hsn);
+	store->open();
+	TSM_ASSERT("Cannot connect to GPU", store->connected());
+
+	const int NNODES = 1000;
+	const int NPAIRS = 1000;  // one pair per adjacent node pair
+
+	// -- Store nodes --
+	auto t0 = std::chrono::high_resolution_clock::now();
+	for (int i = 0; i < NNODES; i++)
+	{
+		Handle h = createNode(CONCEPT_NODE, "tp-" + std::to_string(i));
+		h->setValue(truth_key(), mk_tv((double)i, 0.0));
+		store->storeAtom(h, false);
+	}
+	store->barrier();
+	auto t1 = std::chrono::high_resolution_clock::now();
+
+	double node_ms = std::chrono::duration<double, std::milli>(t1-t0).count();
+	double node_rate = NNODES * 1000.0 / node_ms;
+
+	// -- Store pairs: (tp-i, tp-i+1) for i in [0, NPAIRS) --
+	// Each pair is unique since each (i, i+1) is a distinct pair.
+	auto t2 = std::chrono::high_resolution_clock::now();
+	for (int i = 0; i < NPAIRS; i++)
+	{
+		int a = i;
+		int b = (i + 1) % NNODES;
+		Handle ha = createNode(CONCEPT_NODE, "tp-" + std::to_string(a));
+		Handle hb = createNode(CONCEPT_NODE, "tp-" + std::to_string(b));
+		Handle lnk = createLink(LIST_LINK, ha, hb);
+		lnk->setValue(truth_key(), mk_tv((double)i, 0.0));
+		store->storeAtom(lnk, false);
+	}
+	store->barrier();
+	auto t3 = std::chrono::high_resolution_clock::now();
+
+	double pair_ms = std::chrono::duration<double, std::milli>(t3-t2).count();
+	double pair_rate = NPAIRS * 1000.0 / pair_ms;
+
+	// -- Load all --
+	AtomSpacePtr load_as = createAtomSpace();
+	auto t4 = std::chrono::high_resolution_clock::now();
+	store->loadAtomSpace(load_as.get());
+	store->barrier();
+	auto t5 = std::chrono::high_resolution_clock::now();
+
+	double load_ms = std::chrono::duration<double, std::milli>(t5-t4).count();
+	size_t loaded = load_as->get_size();
+	double load_rate = loaded * 1000.0 / load_ms;
+
+	printf("\n");
+	printf("  ====== GPU Throughput Showcase ======\n");
+	printf("  Backend: %s\n", store->monitor().c_str());
+	printf("  Store %d nodes:   %.1f ms  (%.0f nodes/sec)\n",
+	       NNODES, node_ms, node_rate);
+	printf("  Store %d pairs:  %.1f ms  (%.0f pairs/sec)\n",
+	       NPAIRS, pair_ms, pair_rate);
+	printf("  Load  %lu atoms:  %.1f ms  (%.0f atoms/sec)\n",
+	       loaded, load_ms, load_rate);
+	printf("  =====================================\n\n");
+
+	// Sanity check: should have NNODES nodes + NPAIRS links
+	TSM_ASSERT("Too few atoms loaded",
+		loaded >= (size_t)(NNODES + NPAIRS));
+
+	store->erase();
+	store->close();
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+/* ============================= END OF FILE ================= */

--- a/tests/persist/gpu/GpuIncomingUTest.cxxtest
+++ b/tests/persist/gpu/GpuIncomingUTest.cxxtest
@@ -1,0 +1,579 @@
+/*
+ * tests/persist/gpu/GpuIncomingUTest.cxxtest
+ *
+ * Phase 2 tests: fetchIncomingByType, fetchIncomingSet, loadType.
+ * Verifies that the GPU parallel incoming-set scan correctly finds
+ * all pairs referencing a given word.
+ *
+ * Copyright (C) 2025 OpenCog Foundation
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include <cstdio>
+#include <cmath>
+
+#include <opencog/atoms/base/Atom.h>
+#include <opencog/atoms/base/Link.h>
+#include <opencog/atoms/base/Node.h>
+#include <opencog/atoms/atom_types/atom_types.h>
+#include <opencog/atoms/value/FloatValue.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/persist/gpu/GpuStorageNode.h>
+#include <opencog/persist/gpu-types/atom_types.h>
+
+#include <opencog/util/Logger.h>
+
+#include <cxxtest/TestSuite.h>
+
+using namespace opencog;
+
+// ============================================================
+
+class GpuIncomingUTest : public CxxTest::TestSuite
+{
+private:
+    std::string uri;
+
+    // Helper: create a GPU store, open it, erase it
+    GpuStorageNodePtr make_store(AtomSpacePtr as)
+    {
+        Handle hsn = as->add_node(GPU_STORAGE_NODE, std::string(uri));
+        GpuStorageNodePtr store = GpuStorageNodeCast(hsn);
+        store->open();
+        store->erase();
+        return store;
+    }
+
+public:
+    GpuIncomingUTest(void)
+    {
+        logger().set_level(Logger::INFO);
+        logger().set_print_to_stdout_flag(true);
+        logger().set_sync_flag(true);
+
+        uri = "gpu://:";
+    }
+
+    ~GpuIncomingUTest() {}
+
+    void setUp(void) {}
+    void tearDown(void) {}
+
+    void test_incoming_by_type(void);
+    void test_incoming_empty(void);
+    void test_incoming_with_values(void);
+    void test_incoming_both_sides(void);
+    void test_load_type_words(void);
+    void test_load_type_pairs(void);
+    void test_fetch_incoming_set(void);
+    void test_large_incoming(void);
+    void test_incoming_after_store(void);
+    void test_load_atomspace_pairs(void);
+};
+
+// ============================================================
+// Test 1: Store 3 pairs (A-B, A-C, A-D), fetch incoming for A.
+// Should find all 3.
+
+void GpuIncomingUTest::test_incoming_by_type(void)
+{
+    logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+    AtomSpacePtr as = createAtomSpace();
+    GpuStorageNodePtr store = make_store(as);
+
+    // Store three pairs all sharing word "alpha"
+    Handle alpha(createNode(SCHEMA_NODE, "alpha"));
+    Handle beta(createNode(SCHEMA_NODE, "beta"));
+    Handle gamma(createNode(SCHEMA_NODE, "gamma"));
+    Handle delta(createNode(SCHEMA_NODE, "delta"));
+
+    Handle ab(createLink(LIST_LINK, alpha, beta));
+    Handle ac(createLink(LIST_LINK, alpha, gamma));
+    Handle ad(createLink(LIST_LINK, alpha, delta));
+
+    store->storeAtom(ab, true);
+    store->storeAtom(ac, true);
+    store->storeAtom(ad, true);
+    store->barrier();
+    printf("Stored 3 pairs sharing 'alpha'\n");
+
+    // Fetch incoming set for alpha in a fresh AtomSpace
+    AtomSpacePtr as2 = createAtomSpace();
+    Handle alpha2 = as2->add_node(SCHEMA_NODE, "alpha");
+    store->fetchIncomingByType(as2.get(), alpha2, LIST_LINK);
+
+    // Count links in the new AtomSpace
+    HandleSeq links;
+    as2->get_handles_by_type(links, LIST_LINK, true);
+    printf("Found %zu incoming links for alpha\n", links.size());
+
+    TSM_ASSERT_EQUALS("Should find 3 incoming links", links.size(), 3);
+
+    store->erase();
+    store->close();
+
+    logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// ============================================================
+// Test 2: Fetch incoming for word with no pairs. Returns empty.
+
+void GpuIncomingUTest::test_incoming_empty(void)
+{
+    logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+    AtomSpacePtr as = createAtomSpace();
+    GpuStorageNodePtr store = make_store(as);
+
+    // Store a lone word (no pairs)
+    Handle alone(createNode(SCHEMA_NODE, "alone"));
+    store->storeAtom(alone, true);
+    store->barrier();
+
+    // Also store a pair between OTHER words so pool isn't empty
+    Handle x(createNode(SCHEMA_NODE, "x"));
+    Handle y(createNode(SCHEMA_NODE, "y"));
+    Handle xy(createLink(LIST_LINK, x, y));
+    store->storeAtom(xy, true);
+    store->barrier();
+
+    // Fetch incoming for "alone"
+    AtomSpacePtr as2 = createAtomSpace();
+    Handle alone2 = as2->add_node(SCHEMA_NODE, "alone");
+    store->fetchIncomingByType(as2.get(), alone2, LIST_LINK);
+
+    HandleSeq links;
+    as2->get_handles_by_type(links, LIST_LINK, true);
+    printf("Found %zu incoming links for 'alone'\n", links.size());
+
+    TSM_ASSERT_EQUALS("Should find 0 incoming links", links.size(), 0);
+
+    store->erase();
+    store->close();
+
+    logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// ============================================================
+// Test 3: Verify fetched pairs have correct counts and MI.
+
+void GpuIncomingUTest::test_incoming_with_values(void)
+{
+    logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+    AtomSpacePtr as = createAtomSpace();
+    GpuStorageNodePtr store = make_store(as);
+
+    Handle a(createNode(SCHEMA_NODE, "wordA"));
+    Handle b(createNode(SCHEMA_NODE, "wordB"));
+    Handle lnk(createLink(LIST_LINK, a, b));
+
+    double expected_count = 42.5;
+    double expected_mi = 3.14159;
+    lnk->setValue(truth_key(),
+        createFloatValue(std::vector<double>({expected_count, expected_mi})));
+
+    store->storeAtom(lnk, true);
+    store->barrier();
+    printf("Stored pair with count=%g mi=%g\n", expected_count, expected_mi);
+
+    // Fetch incoming for wordA
+    AtomSpacePtr as2 = createAtomSpace();
+    Handle a2 = as2->add_node(SCHEMA_NODE, "wordA");
+    store->fetchIncomingByType(as2.get(), a2, LIST_LINK);
+
+    HandleSeq links;
+    as2->get_handles_by_type(links, LIST_LINK, true);
+    TSM_ASSERT_EQUALS("Should find 1 link", links.size(), 1);
+
+    if (links.size() == 1)
+    {
+        ValuePtr tv = links[0]->getValue(truth_key());
+        TSM_ASSERT("Should have truth value", tv != nullptr);
+
+        if (tv)
+        {
+            FloatValuePtr fv = FloatValueCast(tv);
+            TSM_ASSERT("Should be FloatValue", fv != nullptr);
+
+            if (fv and fv->value().size() >= 2)
+            {
+                TSM_ASSERT_DELTA("Count mismatch",
+                    fv->value()[0], expected_count, 1e-10);
+                TSM_ASSERT_DELTA("MI mismatch",
+                    fv->value()[1], expected_mi, 1e-10);
+                printf("Values match: count=%g mi=%g\n",
+                    fv->value()[0], fv->value()[1]);
+            }
+        }
+    }
+
+    store->erase();
+    store->close();
+
+    logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// ============================================================
+// Test 4: Word appears as both word_a and word_b. Should find all.
+
+void GpuIncomingUTest::test_incoming_both_sides(void)
+{
+    logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+    AtomSpacePtr as = createAtomSpace();
+    GpuStorageNodePtr store = make_store(as);
+
+    // "center" appears on both sides of different pairs
+    Handle center(createNode(SCHEMA_NODE, "center"));
+    Handle left1(createNode(SCHEMA_NODE, "left1"));
+    Handle left2(createNode(SCHEMA_NODE, "left2"));
+    Handle right1(createNode(SCHEMA_NODE, "right1"));
+
+    // center is word_a (or word_b depending on canonical ordering)
+    Handle l1(createLink(LIST_LINK, left1, center));
+    Handle l2(createLink(LIST_LINK, left2, center));
+    Handle l3(createLink(LIST_LINK, center, right1));
+
+    store->storeAtom(l1, true);
+    store->storeAtom(l2, true);
+    store->storeAtom(l3, true);
+    store->barrier();
+    printf("Stored 3 pairs with 'center' on both sides\n");
+
+    // Fetch incoming for center
+    AtomSpacePtr as2 = createAtomSpace();
+    Handle c2 = as2->add_node(SCHEMA_NODE, "center");
+    store->fetchIncomingByType(as2.get(), c2, LIST_LINK);
+
+    HandleSeq links;
+    as2->get_handles_by_type(links, LIST_LINK, true);
+    printf("Found %zu incoming links for 'center'\n", links.size());
+
+    TSM_ASSERT_EQUALS("Should find 3 incoming links", links.size(), 3);
+
+    store->erase();
+    store->close();
+
+    logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// ============================================================
+// Test 5: Store 50 words, loadType(SCHEMA_NODE), verify all present.
+
+void GpuIncomingUTest::test_load_type_words(void)
+{
+    logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+    AtomSpacePtr as = createAtomSpace();
+    GpuStorageNodePtr store = make_store(as);
+
+    const int N = 50;
+    for (int i = 0; i < N; i++)
+    {
+        std::string name = "loadWord_" + std::to_string(i);
+        Handle h(createNode(SCHEMA_NODE, name));
+        double count = (double)(i + 1);
+        double marginal = count * 0.5;
+        h->setValue(truth_key(),
+            createFloatValue(std::vector<double>({count, marginal})));
+        store->storeAtom(h, false);
+    }
+    store->barrier();
+    printf("Stored %d words\n", N);
+
+    // Load into fresh AtomSpace
+    AtomSpacePtr as2 = createAtomSpace();
+    store->loadType(as2.get(), SCHEMA_NODE);
+
+    HandleSeq nodes;
+    as2->get_handles_by_type(nodes, SCHEMA_NODE, true);
+    printf("loadType found %zu nodes\n", nodes.size());
+
+    // Should find at least N nodes (may also include the
+    // GpuStorageNode itself, which is SCHEMA_NODE subtype)
+    TSM_ASSERT_LESS_THAN_EQUALS("Should find at least N words",
+        (size_t)N, nodes.size());
+
+    // Verify values for a few
+    for (int i = 0; i < N; i++)
+    {
+        std::string name = "loadWord_" + std::to_string(i);
+        Handle h = as2->get_node(SCHEMA_NODE, std::string(name));
+        if (nullptr == h) continue;
+
+        ValuePtr tv = h->getValue(truth_key());
+        if (tv)
+        {
+            FloatValuePtr fv = FloatValueCast(tv);
+            if (fv and fv->value().size() >= 2)
+            {
+                double expected_count = (double)(i + 1);
+                TSM_ASSERT_DELTA("Count mismatch",
+                    fv->value()[0], expected_count, 1e-10);
+            }
+        }
+    }
+
+    store->erase();
+    store->close();
+
+    logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// ============================================================
+// Test 6: Store 20 pairs, loadType(LIST_LINK), verify all present
+// with values.
+
+void GpuIncomingUTest::test_load_type_pairs(void)
+{
+    logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+    AtomSpacePtr as = createAtomSpace();
+    GpuStorageNodePtr store = make_store(as);
+
+    const int N = 20;
+    for (int i = 0; i < N; i++)
+    {
+        std::string na = "pairLeft_" + std::to_string(i);
+        std::string nb = "pairRight_" + std::to_string(i);
+        Handle ha(createNode(SCHEMA_NODE, na));
+        Handle hb(createNode(SCHEMA_NODE, nb));
+        Handle lnk(createLink(LIST_LINK, ha, hb));
+
+        double count = (double)(i + 1) * 10.0;
+        double mi = (double)(i + 1) * 0.25;
+        lnk->setValue(truth_key(),
+            createFloatValue(std::vector<double>({count, mi})));
+
+        store->storeAtom(lnk, false);
+    }
+    store->barrier();
+    printf("Stored %d pairs\n", N);
+
+    // Load pairs into fresh AtomSpace
+    AtomSpacePtr as2 = createAtomSpace();
+    store->loadType(as2.get(), LIST_LINK);
+
+    HandleSeq links;
+    as2->get_handles_by_type(links, LIST_LINK, true);
+    printf("loadType found %zu links\n", links.size());
+
+    TSM_ASSERT_EQUALS("Should find N pairs", links.size(), (size_t)N);
+
+    // Verify at least one has correct values
+    int verified = 0;
+    for (const Handle& lnk : links)
+    {
+        ValuePtr tv = lnk->getValue(truth_key());
+        if (tv)
+        {
+            FloatValuePtr fv = FloatValueCast(tv);
+            if (fv and fv->value().size() >= 2)
+            {
+                // Values should be non-zero
+                TSM_ASSERT("Count should be positive", fv->value()[0] > 0);
+                verified++;
+            }
+        }
+    }
+    printf("Verified values on %d / %zu pairs\n", verified, links.size());
+    TSM_ASSERT_EQUALS("All pairs should have values", verified, N);
+
+    store->erase();
+    store->close();
+
+    logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// ============================================================
+// Test 7: Same as test 1 but via fetchIncomingSet (no type filter).
+
+void GpuIncomingUTest::test_fetch_incoming_set(void)
+{
+    logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+    AtomSpacePtr as = createAtomSpace();
+    GpuStorageNodePtr store = make_store(as);
+
+    Handle a(createNode(SCHEMA_NODE, "hub"));
+    Handle b(createNode(SCHEMA_NODE, "spoke1"));
+    Handle c(createNode(SCHEMA_NODE, "spoke2"));
+
+    Handle ab(createLink(LIST_LINK, a, b));
+    Handle ac(createLink(LIST_LINK, a, c));
+
+    store->storeAtom(ab, true);
+    store->storeAtom(ac, true);
+    store->barrier();
+    printf("Stored 2 pairs sharing 'hub'\n");
+
+    // Use fetchIncomingSet (no type filter)
+    AtomSpacePtr as2 = createAtomSpace();
+    Handle a2 = as2->add_node(SCHEMA_NODE, "hub");
+    store->fetchIncomingSet(as2.get(), a2);
+
+    HandleSeq links;
+    as2->get_handles_by_type(links, LIST_LINK, true);
+    printf("fetchIncomingSet found %zu links\n", links.size());
+
+    TSM_ASSERT_EQUALS("Should find 2 incoming links", links.size(), 2);
+
+    store->erase();
+    store->close();
+
+    logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// ============================================================
+// Test 8: Store 1000 pairs for one word, fetch incoming.
+// Verify all 1000 found.
+
+void GpuIncomingUTest::test_large_incoming(void)
+{
+    logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+    AtomSpacePtr as = createAtomSpace();
+    GpuStorageNodePtr store = make_store(as);
+
+    const int N = 1000;
+    Handle hub(createNode(SCHEMA_NODE, "megahub"));
+    store->storeAtom(hub, true);
+
+    for (int i = 0; i < N; i++)
+    {
+        std::string name = "spoke_" + std::to_string(i);
+        Handle spoke(createNode(SCHEMA_NODE, name));
+        Handle lnk(createLink(LIST_LINK, hub, spoke));
+        store->storeAtom(lnk, false);
+    }
+    store->barrier();
+    printf("Stored %d pairs sharing 'megahub'\n", N);
+
+    // Fetch incoming
+    AtomSpacePtr as2 = createAtomSpace();
+    Handle hub2 = as2->add_node(SCHEMA_NODE, "megahub");
+    store->fetchIncomingByType(as2.get(), hub2, LIST_LINK);
+
+    HandleSeq links;
+    as2->get_handles_by_type(links, LIST_LINK, true);
+    printf("Found %zu incoming links for megahub\n", links.size());
+
+    TSM_ASSERT_EQUALS("Should find all N links", links.size(), (size_t)N);
+
+    store->erase();
+    store->close();
+
+    logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// ============================================================
+// Test 9: Store new pair after initial fetch, re-fetch, find it.
+
+void GpuIncomingUTest::test_incoming_after_store(void)
+{
+    logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+    AtomSpacePtr as = createAtomSpace();
+    GpuStorageNodePtr store = make_store(as);
+
+    Handle a(createNode(SCHEMA_NODE, "evolving"));
+    Handle b(createNode(SCHEMA_NODE, "partner1"));
+    Handle ab(createLink(LIST_LINK, a, b));
+    store->storeAtom(ab, true);
+    store->barrier();
+
+    // First fetch: should find 1
+    AtomSpacePtr as2 = createAtomSpace();
+    Handle a2 = as2->add_node(SCHEMA_NODE, "evolving");
+    store->fetchIncomingByType(as2.get(), a2, LIST_LINK);
+
+    HandleSeq links1;
+    as2->get_handles_by_type(links1, LIST_LINK, true);
+    printf("First fetch: %zu links\n", links1.size());
+    TSM_ASSERT_EQUALS("Should find 1 link initially", links1.size(), 1);
+
+    // Store another pair
+    Handle c(createNode(SCHEMA_NODE, "partner2"));
+    Handle ac(createLink(LIST_LINK, a, c));
+    store->storeAtom(ac, true);
+    store->barrier();
+
+    // Second fetch: should find 2
+    AtomSpacePtr as3 = createAtomSpace();
+    Handle a3 = as3->add_node(SCHEMA_NODE, "evolving");
+    store->fetchIncomingByType(as3.get(), a3, LIST_LINK);
+
+    HandleSeq links2;
+    as3->get_handles_by_type(links2, LIST_LINK, true);
+    printf("Second fetch: %zu links\n", links2.size());
+    TSM_ASSERT_EQUALS("Should find 2 links after adding", links2.size(), 2);
+
+    store->erase();
+    store->close();
+
+    logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// ============================================================
+// Test 10: loadAtomSpace loads both words AND pairs
+
+void GpuIncomingUTest::test_load_atomspace_pairs(void)
+{
+    logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+    AtomSpacePtr as = createAtomSpace();
+    GpuStorageNodePtr store = make_store(as);
+
+    // Store some words and pairs
+    Handle a(createNode(SCHEMA_NODE, "loadAll_A"));
+    Handle b(createNode(SCHEMA_NODE, "loadAll_B"));
+    Handle c(createNode(SCHEMA_NODE, "loadAll_C"));
+
+    a->setValue(truth_key(),
+        createFloatValue(std::vector<double>({1.0, 0.1})));
+    b->setValue(truth_key(),
+        createFloatValue(std::vector<double>({2.0, 0.2})));
+
+    Handle ab(createLink(LIST_LINK, a, b));
+    ab->setValue(truth_key(),
+        createFloatValue(std::vector<double>({10.0, 5.5})));
+
+    Handle ac(createLink(LIST_LINK, a, c));
+    ac->setValue(truth_key(),
+        createFloatValue(std::vector<double>({20.0, 7.7})));
+
+    store->storeAtom(ab, true);
+    store->storeAtom(ac, true);
+    store->barrier();
+    printf("Stored 3 nodes + 2 pairs\n");
+
+    // Load words only (existing loadAtomSpace)
+    AtomSpacePtr as2 = createAtomSpace();
+    store->loadAtomSpace(as2.get());
+
+    HandleSeq nodes;
+    as2->get_handles_by_type(nodes, SCHEMA_NODE, true);
+    printf("loadAtomSpace found %zu nodes\n", nodes.size());
+
+    TSM_ASSERT_LESS_THAN_EQUALS("Should find at least 3 nodes",
+        (size_t)3, nodes.size());
+
+    // Now also load pairs via loadType
+    store->loadType(as2.get(), LIST_LINK);
+
+    HandleSeq links;
+    as2->get_handles_by_type(links, LIST_LINK, true);
+    printf("loadType(LIST_LINK) found %zu pairs\n", links.size());
+
+    TSM_ASSERT_EQUALS("Should find 2 pairs", links.size(), 2);
+
+    store->erase();
+    store->close();
+
+    logger().info("END TEST: %s", __FUNCTION__);
+}
+
+/* ============================= END OF FILE ================= */


### PR DESCRIPTION
## Summary

- **Type storage**: Added `uint16_t` type column to word pool, repurposed `pair_flags` for link type. Golden-ratio type hashing prevents same-name-different-type collisions (ConceptNode "foo" vs SchemaNode "foo" now get separate GPU slots).
- **Incoming set scan**: New `gpu-incoming.cl` (OpenCL) and `cuda_incoming_scan` (CUDA) kernels — parallel scan of pair pool with atomic match counter. `fetchIncomingByType` filters by link type.
- **Bulk operations**: `loadAtomSpace`, `loadType`, `storeAtomSpace` iterate GPU pool slots directly.
- **3 new test files**: BasicSaveUTest (round-trip), GpuIncomingUTest (incoming + loadType), GpuBulkUTest (multi-type, collision safety, bulk, throughput showcase).

## Known limitations

- **Pair pool key**: `(min(a,b), max(a,b))` — one slot per node pair. Multiple link types between the same two nodes share a slot (last write wins). Tests use distinct node pairs per link type. See #2 for design exploration on fixing this.
- **Store throughput**: `storeAtom` does per-atom host→GPU transfers (~35K nodes/sec). GpuBulkUTest uses reduced scale to pass within CI timeout. Load path is fast (~700K atoms/sec) since it reads GPU pools in bulk.

## Test results

16/16 pass (12 kernel tests + 4 StorageNode tests). The `test-compartment-kernel` benchmark is excluded from default timeout — it runs a full GPU learning simulation (~30 min).

## Files changed (13)

| File | Change |
|------|--------|
| `opencog/gpu/CMakeLists.txt` | Register gpu-incoming.cl |
| `opencog/gpu/gpu-incoming.cl` | **New** — OpenCL incoming scan kernel |
| `opencog/persist/gpu/GpuBackend.h` | 6 new type read/write methods |
| `opencog/persist/gpu/CudaBackend.h` + `.cu` | CUDA type column + incoming scan |
| `opencog/persist/gpu/OpenCLBackend.h` + `.cc` | OpenCL type column + incoming scan |
| `opencog/persist/gpu/GpuStorageNode.h` | TypedName maps, type-aware signatures |
| `opencog/persist/gpu/GpuStorageNode.cc` | Full rewrite: type-aware store/fetch/load |
| `tests/persist/gpu/CMakeLists.txt` | Register 3 new tests |
| `tests/persist/gpu/BasicSaveUTest.cxxtest` | **New** — basic round-trip test |
| `tests/persist/gpu/GpuIncomingUTest.cxxtest` | **New** — incoming set + loadType |
| `tests/persist/gpu/GpuBulkUTest.cxxtest` | **New** — 6 subtests: multi-type, collision, bulk, throughput |

## Test plan

- [x] 16/16 tests pass locally (RTX 2070, CUDA backend)
- [ ] Verify OpenCL-only path on non-NVIDIA hardware
- [ ] Stress test at larger scale (10K+ atoms) outside CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)